### PR TITLE
fix(postinstall): make system service executable only by the user

### DIFF
--- a/mac/resources/scripts/postinstall
+++ b/mac/resources/scripts/postinstall
@@ -534,7 +534,7 @@ setup_user_permissions() {
     fi
     
     if [[ -f "${BIN_DIR}/gnosis_vpn-ctl" ]]; then
-        chown root:$groupname "${BIN_DIR}/gnosis_vpn-ctl"
+        chown $username:wheel "${BIN_DIR}/gnosis_vpn-ctl"
         chmod 750 "${BIN_DIR}/gnosis_vpn-ctl"
         log_info "CLI binary permissions updated: ${BIN_DIR}/gnosis_vpn-ctl"
     fi


### PR DESCRIPTION
This pull request makes a targeted update to the permissions logic for the `gnosis_vpn-ctl` CLI binary in the post-installation script. The change ensures that ownership of the binary is set to the specific user and the `wheel` group, rather than `root` and a variable group.

* Permissions update for CLI binary:
  * In `mac/resources/scripts/postinstall`, the ownership of `gnosis_vpn-ctl` is now set to `$username:wheel` instead of `root:$groupname`, improving clarity and aligning with standard macOS administrative practices.
  
  
## Notes
Fixes #1 