### PR TITLE
fix: set mixer delay for outgoing packet to a reasonable edge client 

### DIFF
--- a/mac/resources/config/system/org.gnosis.vpn.plist
+++ b/mac/resources/config/system/org.gnosis.vpn.plist
@@ -67,6 +67,8 @@
         <string>/var/lib/gnosis_vpn</string>
         <key>RUST_LOG</key>
         <string>info</string>
+        <key>HOPR_INTERNAL_MIXER_MINIMUM_DELAY_IN_MS</key>
+        <string>0</string>
         <key>HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS</key>
         <string>5</string>
     </dict>


### PR DESCRIPTION
This pull request adds a new environment variable to control the internal mixer delay range. The mixer only mixes the node data, so it might as well not be there for the edge client.


## AI description
This pull request introduces configuration changes to the `org.gnosis.vpn.plist` file to support new mixer delay settings for the HOPR internal mixer. These changes allow for finer control over the minimum and range of mixer delays, which can help with performance tuning and privacy settings.

Mixer delay configuration:

* Added `HOPR_INTERNAL_MIXER_MINIMUM_DELAY_IN_MS` and set its value to `0` to specify the minimum delay for the internal mixer.
* Added `HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS` and set its value to `5` to specify the range of delay for the internal mixer.
