### PR TITLE
feat: append generated notes to releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,6 @@ on:
         required: true
         type: boolean
         default: true
-
 concurrency:
   group: release
   cancel-in-progress: false
@@ -94,13 +93,21 @@ jobs:
         if: inputs.public_release
         run: |
           release_version=$(cat LATEST)
-          cat > release_notes.txt <<EOF
+
+          cat > release_header.txt <<EOF
           Release v${release_version} of GnosisVPN.
           - Client version: v${{ steps.package.outputs.GNOSISVPN_CLI_VERSION }}
           - App version: v${{ steps.package.outputs.GNOSISVPN_APP_VERSION }}
+
           EOF
-          gh release create v${release_version} --title "GnosisVPN v${release_version}" --notes-file release_notes.txt
-          rm release_notes.txt
+
+          gh release create v${release_version} \
+            --title "GnosisVPN v${release_version}" \
+            --notes-file release_header.txt \
+            --generate-notes
+
+          rm release_header.txt
+
           echo "Preparing binaries for upload"
           gh release upload v${release_version} "./binaries/GnosisVPN-Installer.pkg" --clobber
           gh release upload v${release_version} "./binaries/GnosisVPN-Installer.pkg.sha256" --clobber


### PR DESCRIPTION
The docs state it should work with `--notes` parameter: https://cli.github.com/manual/gh_release_create

Let's see if this works with `--notes-file` as well