### PR TITLE
Change log path in Mac Installer

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,11 +19,6 @@ on:
         required: true
         type: string
         default: "latest"
-      sign:
-        description: "Sign the package"
-        required: true
-        type: boolean
-        default: true
 concurrency:
   group: release
   cancel-in-progress: false
@@ -92,14 +87,13 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Setup GPG key for signing
-        if: inputs.sign
         run: |
           echo "${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY }}" > /tmp/gnosis_vpn_gpg_key.asc
           chmod 600 /tmp/gnosis_vpn_gpg_key.asc
       - name: Build Linux package
         shell: bash
         run: |
-          nix develop -c just all ${{ matrix.distribution }} ${{ matrix.architecture.nix }} ${{ inputs.sign || false }}
+          nix develop -c just all ${{ matrix.distribution }} ${{ matrix.architecture.nix }} true
         env:
           GH_TOKEN: ${{ github.token }}
           GNOSISVPN_PACKAGE_VERSION: ${{ needs.setup.outputs.GNOSISVPN_PACKAGE_VERSION }}
@@ -116,7 +110,6 @@ jobs:
           name: gnosisvpn_${{ needs.setup.outputs.GNOSISVPN_PACKAGE_VERSION }}_${{ matrix.architecture.nfpm }}.${{ matrix.distribution }}
           path: ./build/packages/gnosisvpn_${{ needs.setup.outputs.GNOSISVPN_PACKAGE_VERSION }}_${{ matrix.architecture.nfpm }}.${{ matrix.distribution }}
       - name: Upload Signature
-        if: inputs.sign
         uses: actions/upload-artifact@v5
         with:
           name: gnosisvpn_${{ needs.setup.outputs.GNOSISVPN_PACKAGE_VERSION }}_${{ matrix.architecture.nfpm }}.${{ matrix.distribution }}.asc
@@ -144,13 +137,11 @@ jobs:
       - name: Create mac installer package
         shell: bash
         run: |
-          if [[ -z "${{ inputs.sign }}" ]] || [[ "${{ inputs.sign }}" = true ]]; then
-            echo "${{ secrets.GNOSISVPN_APPLE_CERTIFICATE_DEVELOPER }}" | base64 --decode > gnosisvpn-developer.p12
-            echo "${{ secrets.GNOSISVPN_APPLE_CERTIFICATE_INSTALLER }}" | base64 --decode > gnosisvpn-installer.p12
-            export GNOSISVPN_APPLE_CERTIFICATE_DEVELOPER_PATH=$(pwd)/gnosisvpn-developer.p12
-            export GNOSISVPN_APPLE_CERTIFICATE_INSTALLER_PATH=$(pwd)/gnosisvpn-installer.p12
-          fi
-          nix develop -c just all dmg aarch64-darwin ${{ inputs.sign || false }}
+          echo "${{ secrets.GNOSISVPN_APPLE_CERTIFICATE_DEVELOPER }}" | base64 --decode > gnosisvpn-developer.p12
+          echo "${{ secrets.GNOSISVPN_APPLE_CERTIFICATE_INSTALLER }}" | base64 --decode > gnosisvpn-installer.p12
+          export GNOSISVPN_APPLE_CERTIFICATE_DEVELOPER_PATH=$(pwd)/gnosisvpn-developer.p12
+          export GNOSISVPN_APPLE_CERTIFICATE_INSTALLER_PATH=$(pwd)/gnosisvpn-installer.p12
+          nix develop -c just all dmg aarch64-darwin true
           mv ./build/packages/GnosisVPN-Installer-*-signed.pkg "./build/packages/GnosisVPN-Installer.pkg"
           mv ./build/packages/GnosisVPN-Installer-*-signed.pkg.sha256 "./build/packages/GnosisVPN-Installer.pkg.sha256"
         env:

--- a/mac/README.md
+++ b/mac/README.md
@@ -53,8 +53,8 @@ After installation, files are located at:
   - `gnosis_vpn-ctl` - Control utility
 - Application: `/Applications/Gnosis VPN.app`
 - Configuration: `/etc/gnosisvpn/config.toml`
-- Logs Pre-install: `/Library/Logs/GnosisVPNInstaller/preinstall.log`
-- Logs Post-install: `/Library/Logs/GnosisVPNInstaller/postinstall.log`
+- Logs Pre-install: `/Library/Logs/GnosisVPN/installer/preinstall.log`
+- Logs Post-install: `/Library/Logs/GnosisVPN/installer/postinstall.log`
 
 ## Uninstallation
 
@@ -66,39 +66,6 @@ To completely remove Gnosis VPN from your system:
 cd mac
 sudo ./uninstall.sh
 ```
-
-The uninstall script will:
-
-- Back up your configuration to `~/gnosis-vpn-config-backup-*`
-- Remove binaries from `/usr/local/bin/`
-- Remove configuration from `/etc/gnosisvpn/`
-- Remove installation logs from `/Library/Logs/GnosisVPNInstaller/`
-- Forget the package receipt
-
-### Option 2: Manual Uninstallation
-
-If you prefer to uninstall manually:
-
-1. **Remove the binaries:**
-   ```bash
-   sudo rm -f /usr/local/bin/gnosis_vpn*
-   ```
-
-2. **Remove the configuration (backup first if needed):**
-   ```bash
-   sudo cp -R /etc/gnosisvpn ~/gnosis-vpn-config-backup
-   sudo rm -rf /etc/gnosisvpn
-   ```
-
-3. **Remove installation logs:**
-   ```bash
-   sudo rm -rf /Library/Logs/GnosisVPNInstaller
-   ```
-
-4. **Forget the package receipt:**
-   ```bash
-   sudo pkgutil --forget org.gnosis.vpn.client
-   ```
 
 ## Security
 

--- a/mac/resources/config/README.md
+++ b/mac/resources/config/README.md
@@ -27,7 +27,7 @@ VPN service.
 - Automatic startup on system boot (`RunAtLoad=true`)
 - Automatic restart on crashes (`KeepAlive`)
 - Resource limits and security configuration
-- Logging to `/var/log/gnosisvpn/`
+- Logging to `/Library/Log/GnosisVPN/`
 - Runs as root with wheel group permissions
 
 ## Configuration Templates

--- a/mac/resources/config/system/com.gnosisvpn.gnosisvpnclient.plist
+++ b/mac/resources/config/system/com.gnosisvpn.gnosisvpnclient.plist
@@ -48,9 +48,9 @@
     
     <!-- Logging Configuration -->
     <key>StandardOutPath</key>
-    <string>/var/log/gnosisvpn/gnosisvpn.log</string>
+    <string>/Library/Logs/GnosisVPN/gnosisvpn.log</string>
     <key>StandardErrorPath</key>
-    <string>/var/log/gnosisvpn/gnosisvpn.log</string>
+    <string>/Library/Logs/GnosisVPN/gnosisvpn.log</string>
     
     <!-- Environment Variables -->
     <key>EnvironmentVariables</key>

--- a/mac/resources/scripts/logging.sh
+++ b/mac/resources/scripts/logging.sh
@@ -15,7 +15,7 @@
 #
 
 # Default log directory and file
-INSTALLER_LOG_DIR="${INSTALLER_LOG_DIR:-/Library/Logs/GnosisVPNInstaller}"
+INSTALLER_LOG_DIR="${INSTALLER_LOG_DIR:-/Library/Logs/GnosisVPN/installer}"
 INSTALLER_LOG_FILE="${INSTALLER_LOG_FILE:-${INSTALLER_LOG_DIR}/installer.log}"
 
 # Setup logging for a script

--- a/mac/resources/scripts/manage-installation.sh
+++ b/mac/resources/scripts/manage-installation.sh
@@ -26,6 +26,7 @@ CONFIG_DIR="/etc/gnosisvpn"
 VERSION_FILE="${CONFIG_DIR}/version.txt"
 CONFIG_FILE="${CONFIG_DIR}/config.toml"
 BIN_DIR="/usr/local/bin"
+LOGS_DIR="/Library/Logs/GnosisVPN"
 
 # Colors for output
 RED='\033[0;31m'
@@ -363,7 +364,7 @@ start_service() {
         log_success "Service started successfully"
     else
         log_error "Service failed to start"
-        log_info "Check logs: tail -f /var/log/gnosisvpn/gnosisvpn.log"
+        log_info "Check logs: tail -f $LOGS_DIR/gnosisvpn.log"
         exit 1
     fi
 }
@@ -410,7 +411,7 @@ show_logs() {
     "service" | "info")
         log_info "Showing service logs (last 50 lines):"
         echo ""
-        tail -n 50 /var/log/gnosisvpn/gnosisvpn.log 2>/dev/null || {
+        tail -n 50 "$LOGS_DIR/gnosisvpn.log" 2>/dev/null || {
             log_error "Service log file not found"
             exit 1
         }
@@ -418,7 +419,7 @@ show_logs() {
     "error" | "errors")
         log_info "Showing error logs (last 50 lines):"
         echo ""
-        tail -n 50 /var/log/gnosisvpn/gnosisvpn.log 2>/dev/null || {
+        tail -n 50 "$LOGS_DIR/gnosisvpn.log" 2>/dev/null || {
             log_error "Error log file not found"
             exit 1
         }
@@ -426,7 +427,7 @@ show_logs() {
     "follow" | "tail")
         log_info "Following service logs (Ctrl+C to stop):"
         echo ""
-        tail -f /var/log/gnosisvpn/gnosisvpn.log 2>/dev/null || {
+        tail -f "$LOGS_DIR/gnosisvpn.log" 2>/dev/null || {
             log_error "Service log file not found"
             exit 1
         }

--- a/mac/resources/scripts/postinstall
+++ b/mac/resources/scripts/postinstall
@@ -62,7 +62,7 @@ UI_STAGING_DIR="$(join_path "$TARGET_VOLUME" "/usr/local/share/gnosisvpn")"
 UI_STAGED_ARCHIVE="${UI_STAGING_DIR}/gnosis_vpn-app.tar.gz"
 UI_TARGET_APP="$(join_path "$TARGET_VOLUME" "/Applications/Gnosis VPN.app")"
 
-INSTALLED_LOG_DIR_PATH="/var/log/gnosisvpn"
+INSTALLED_LOG_DIR_PATH="/Library/Logs/GnosisVPN"
 INSTALLED_LIB_DIR_PATH="/var/lib/gnosisvpn"
 
 
@@ -419,12 +419,6 @@ install_launchd_service() {
     if [[ ! -f "$source_plist" ]]; then
         source_plist="${SCRIPT_DIR}/../config/system/${plist_name}"
     fi
-    local log_dir="$INSTALLED_LOG_DIR_PATH"
-
-    # Create log directory
-    mkdir -p "$log_dir"
-    chmod 755 "$log_dir"
-    chown gnosisvpn:gnosisvpn "$log_dir" 2>/dev/null || true
 
     # Handle existing service (for updates/reinstalls)
     local service_was_running=false
@@ -513,7 +507,7 @@ install_launchd_service() {
             else
                 log_warn "Service loaded but may not be running yet"
                 log_info "This is normal if binaries haven't been downloaded yet"
-                log_info "Check logs: tail -f $log_dir/gnosisvpn.log"
+                log_info "Check logs: tail -f $INSTALLED_LOG_DIR_PATH/gnosisvpn.log"
             fi
         else
             log_error "Failed to load Gnosis VPN service after $max_attempts attempts"
@@ -678,11 +672,11 @@ check_service_status() {
             log_success "VPN process is running (PID: $pid)"
 
             # Check if logs are being created
-            if [[ -f "$INSTALLED_LOG_DIR_PATH/gnosis_vpn.log" ]]; then
+            if [[ -f "$INSTALLED_LOG_DIR_PATH/gnosisvpn.log" ]]; then
                 local log_size
-                log_size=$(wc -c < $INSTALLED_LOG_DIR_PATH/gnosis_vpn.log 2>/dev/null || echo "0")
+                log_size=$(wc -c < $INSTALLED_LOG_DIR_PATH/gnosisvpn.log 2>/dev/null || echo "0")
                 if [[ "$log_size" -gt 0 ]]; then
-                    log_success "Service is logging to $INSTALLED_LOG_DIR_PATH/gnosis_vpn.log"
+                    log_success "Service is logging to $INSTALLED_LOG_DIR_PATH/gnosisvpn.log"
                 else
                     log_info "Log file exists but is empty (service may be starting)"
                 fi

--- a/mac/resources/scripts/uninstall.sh
+++ b/mac/resources/scripts/uninstall.sh
@@ -21,7 +21,7 @@ NC='\033[0m' # No Color
 PKG_ID="com.gnosisvpn.gnosisvpnclient"
 BIN_DIR="/usr/local/bin"
 CONFIG_DIR="/etc/gnosisvpn"
-LOG_DIR="/Library/Logs/GnosisVPNInstaller"
+LOG_DIR="/Library/Logs/GnosisVPN"
 
 # Logging functions
 log_info() {
@@ -63,8 +63,8 @@ confirm_uninstall() {
     echo "  - Binaries: $BIN_DIR/gnosis_vpn-root, $BIN_DIR/gnosis_vpn-worker, $BIN_DIR/gnosis_vpn-ctl, $BIN_DIR/gnosis_vpn-manager"
     echo "  - Launchd service: /Library/LaunchDaemons/com.gnosisvpn.gnosisvpnclient.plist"
     echo "  - Configuration: $CONFIG_DIR/"
-    echo "  - Service logs: /var/log/gnosisvpn/"
-    echo "  - Installation logs: $LOG_DIR/"
+    echo "  - Service logs: $LOG_DIR"
+    echo "  - Installation logs: $LOG_DIR/installer"
     echo "  - Package receipt: $PKG_ID"
     echo ""
     read -p "Are you sure you want to uninstall Gnosis VPN? [y/N] " -n 1 -r
@@ -156,7 +156,7 @@ cleanup_system_directories() {
     local directories=(
         "/var/run/gnosisvpn"
         "/var/lib/gnosisvpn/Library/Application Support/com.gnosisvpn.gnosisvpnclient/gnosisvpn-hopr.db"
-        "/var/log/gnosisvpn"
+        "$LOG_DIR"
     )
 
     for dir in "${directories[@]}"; do
@@ -314,22 +314,13 @@ remove_config() {
 
 # Remove logs
 remove_logs() {
-    log_info "Removing installation logs..."
-
+    log_info "Removing logs..."
     if [[ -d $LOG_DIR ]]; then
         rm -rf "$LOG_DIR"
         log_success "Removed $LOG_DIR"
     else
         log_warn "Log directory not found"
     fi
-
-    # Also remove service logs
-    local service_log_dir="/var/log/gnosisvpn"
-    if [[ -d $service_log_dir ]]; then
-        rm -rf "$service_log_dir"
-        log_success "Removed service logs: $service_log_dir"
-    fi
-
     echo ""
 }
 
@@ -406,7 +397,7 @@ verify_uninstall() {
     fi
 
     # Check system directories removal
-    local system_dirs=("/var/run/gnosisvpn" "/var/log/gnosisvpn")
+    local system_dirs=("/var/run/gnosisvpn" "$LOG_DIR")
     for dir in "${system_dirs[@]}"; do
         if [[ -d $dir ]]; then
             log_error "System directory still exists: $dir"


### PR DESCRIPTION
- Modifies the Mac log path from `/var/log/gnosisvpn` to `/Library/Logs/GnosisVPN` as recommended by MacOS applications.
- Removes the possibility to build binaries unsigned which is probably the reason why the cut of releases at `gnosis_vpn-app` and `gnosis_vpn-client` is not triggering a snpahot release in `gnosis_vpn` repository.