### PR TITLE
fix(env): the environment variables must be passed natively into the worker

### DIFF
--- a/linux/resources/gnosisvpn.env
+++ b/linux/resources/gnosisvpn.env
@@ -7,7 +7,3 @@ HOME=/var/lib/gnosisvpn
 # Rust environment variables
 RUST_LOG=info
 RUST_BACKTRACE=1
-
-# HOPRd environment variables
-HOPR_INTERNAL_MIXER_MINIMUM_DELAY_IN_MS=0
-HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS=5

--- a/mac/resources/config/system/com.gnosisvpn.gnosisvpnclient.plist
+++ b/mac/resources/config/system/com.gnosisvpn.gnosisvpnclient.plist
@@ -69,10 +69,6 @@
         <string>info</string>
         <key>TMPDIR</key>
         <string>/var/lib/gnosisvpn</string>
-        <key>HOPR_INTERNAL_MIXER_MINIMUM_DELAY_IN_MS</key>
-        <string>0</string>
-        <key>HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS</key>
-        <string>5</string>
     </dict>
     
     <!-- Security -->


### PR DESCRIPTION
This pull request removes the configuration of two HOPRd mixer delay environment variables from both Linux and Mac resource files. These variables can no longer be set as part of the system configuration after the worker split.

Configuration cleanup:

* Removed the `HOPR_INTERNAL_MIXER_MINIMUM_DELAY_IN_MS` and `HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS` environment variables from the `linux/resources/gnosisvpn.env` file.
* Removed the `HOPR_INTERNAL_MIXER_MINIMUM_DELAY_IN_MS` and `HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS` entries from the Mac system plist file `mac/resources/config/system/com.gnosisvpn.gnosisvpnclient.plist`.