### PR TITLE
feat: Externalize all parameters as environment variables

### DIFF
--- a/linux/resources/gnosisvpn.env
+++ b/linux/resources/gnosisvpn.env
@@ -3,6 +3,7 @@ GNOSISVPN_CONFIG_PATH=/etc/gnosisvpn/config.toml
 GNOSISVPN_WORKER_BINARY=/usr/bin/gnosis_vpn-worker
 GNOSISVPN_WORKER_USER=gnosisvpn
 HOME=/var/lib/gnosisvpn
+GNOSISVPN_HOPR_BLOKLI_URL=https://blokli.rotsee.hoprnet.link
 
 # Rust environment variables
 RUST_LOG=info

--- a/linux/resources/gnosisvpn.service
+++ b/linux/resources/gnosisvpn.service
@@ -16,7 +16,7 @@ EnvironmentFile=/etc/gnosisvpn/gnosisvpn.env
 WorkingDirectory=/var/lib/gnosisvpn
 
 # Main service command
-ExecStart=/usr/bin/gnosis_vpn-root --hopr-blokli-url https://blokli.rotsee.hoprnet.link
+ExecStart=/usr/bin/gnosis_vpn-root
 
 # Restart configuration
 Restart=always

--- a/mac/resources/config/system/com.gnosisvpn.gnosisvpnclient.plist
+++ b/mac/resources/config/system/com.gnosisvpn.gnosisvpnclient.plist
@@ -10,8 +10,6 @@
     <key>ProgramArguments</key>
     <array>
         <string>/usr/local/bin/gnosis_vpn-root</string>
-        <string>--hopr-blokli-url</string>
-        <string>https://blokli.__NETWORK_NAME__.hoprnet.link</string>
     </array>
 
     <!-- Service Behavior -->
@@ -69,6 +67,8 @@
         <string>/var/run/gnosisvpn/gnosisvpn.pid</string>
         <key>GNOSISVPN_LOG_FILE</key>
         <string>/Library/Logs/GnosisVPN/gnosisvpn.log</string>
+        <key>GNOSISVPN_HOPR_BLOKLI_URL</key>
+        <string>https://blokli.__NETWORK_NAME__.hoprnet.link</string>
         <key>RUST_LOG</key>
         <string>info</string>
         <key>RUST_BACKTRACE</key>


### PR DESCRIPTION
Instead of passing the parameters via command line they are set via the environment variables.
This helps maintenance.