### PR TITLE
Add resolvconf as a dependency in nfpm template

### DIFF
--- a/linux/nfpm-template.yaml
+++ b/linux/nfpm-template.yaml
@@ -27,6 +27,7 @@ overrides:
       - libgtk-3-0
       - libayatana-appindicator3-1
       - libglib2.0-bin
+      - resolvconf
   rpm:
     depends:
       - systemd


### PR DESCRIPTION
This pull request makes a small change to the `linux/nfpm-template.yaml` packaging configuration by adding a new dependency for the Debian package.

* Added `resolvconf` to the list of Debian package dependencies in the `overrides:` section.