### PR TITLE
fix: linux log rotation

### DIFF
--- a/linux/resources/gnosisvpn.env
+++ b/linux/resources/gnosisvpn.env
@@ -4,6 +4,7 @@ GNOSISVPN_WORKER_BINARY=/usr/bin/gnosis_vpn-worker
 GNOSISVPN_WORKER_USER=gnosisvpn
 HOME=/var/lib/gnosisvpn
 GNOSISVPN_HOPR_BLOKLI_URL=https://blokli.jura.hoprnet.link
+GNOSISVPN_LOG_FILE=/var/log/gnosisvpn/gnosisvpn.log
 
 # Rust environment variables
 RUST_LOG=info

--- a/linux/resources/gnosisvpn.service
+++ b/linux/resources/gnosisvpn.service
@@ -26,9 +26,6 @@ RestartSec=5s
 TimeoutStopSec=30
 TimeoutStartSec=60
 
-# Logging
-StandardOutput=append:/var/log/gnosisvpn/gnosisvpn.log
-StandardError=append:/var/log/gnosisvpn/gnosisvpn.log
 SyslogIdentifier=gnosisvpn
 
 # Directory management - systemd will create these with proper permissions

--- a/linux/resources/logrotate.conf
+++ b/linux/resources/logrotate.conf
@@ -6,4 +6,7 @@
     delaycompress
     notifempty
     create 0640 gnosisvpn gnosisvpn
+    postrotate
+        systemctl kill -s HUP gnosisvpn.service 2>/dev/null || true
+    endscript
 }


### PR DESCRIPTION
Upon log rotation, signals the client to refresh the file pointer used to write logs.

Fixes #134 