### PR TITLE
fix: remove Nice priority demotion from launchd plist

### DIFF
--- a/mac/resources/config/system/com.gnosisvpn.gnosisvpnclient.plist
+++ b/mac/resources/config/system/com.gnosisvpn.gnosisvpnclient.plist
@@ -98,7 +98,7 @@
     <key>ExitTimeOut</key>
     <integer>30</integer>
 
-    <!-- Network Condition (optional - only start if network is available) -->
+    <!-- Allow re-launching the service after it has been unloaded and reloaded -->
     <key>LaunchOnlyOnce</key>
     <false/>
 </dict>


### PR DESCRIPTION
## Context

The macOS launchd plist for the VPN daemon had `Nice: 5`, which signals lower scheduler priority. This contradicts the `ProcessType: Interactive` setting and may contribute to the OS deprioritizing the daemon process, making it more susceptible to App Nap and timer coalescing.

## Changes

- Removes `Nice: 5` from `com.gnosisvpn.gnosisvpnclient.plist`
- `ProcessType: Interactive` (already present) is the correct and sufficient mechanism for communicating the daemon's scheduling needs to launchd

## Related PRs

- gnosis/gnosis_vpn-client#442 — Client: adds `app_nap` module to disable App Nap on root and worker processes
- gnosis/gnosis_vpn-app#190 — Tauri app: uses the same module to disable App Nap on the GUI process

Part of the fix for gnosis/gnosis_vpn-app#189

## Test plan

- [ ] Verify the daemon starts correctly on macOS with the updated plist
- [ ] Confirm `ProcessType: Interactive` is still present