### PR TITLE
fix(mac): bundle process-control.sh into installer package

### DIFF
--- a/mac/resources/scripts/postinstall
+++ b/mac/resources/scripts/postinstall
@@ -882,6 +882,7 @@ copy_uninstall() {
     log_info "Copying uninstall script..."
     mkdir -p "$INSTALLED_LIB_DIR_PATH"
     cp "${SCRIPT_DIR}/uninstall.sh" "$INSTALLED_LIB_DIR_PATH/uninstall.sh"
+    cp "${SCRIPT_DIR}/process-control.sh" "$INSTALLED_LIB_DIR_PATH/process-control.sh"
     log_success "Uninstall script copied to $INSTALLED_LIB_DIR_PATH/uninstall.sh"
 }
 

--- a/scripts/generate-package-mac.sh
+++ b/scripts/generate-package-mac.sh
@@ -334,30 +334,21 @@ unpack() {
 copy_scripts() {
     log_info "Copying installation scripts..."
 
-    # Copy logging library (required by all scripts)
-    if [[ -f "$RESOURCES_DIR/scripts/logging.sh" ]]; then
-        cp "$RESOURCES_DIR/scripts/logging.sh" "${BUILD_DIR}/scripts/"
-        log_success "Copied logging library"
-    fi
+    # Copy shared libraries (required by installer scripts)
+    cp "$RESOURCES_DIR/scripts/logging.sh" "${BUILD_DIR}/scripts/"
+    cp "$RESOURCES_DIR/scripts/process-control.sh" "${BUILD_DIR}/scripts/"
+    log_success "Copied shared libraries"
 
-    # Preinstall is now a minimal no-op (optional WireGuard check only)
-    if [[ -f "$RESOURCES_DIR/scripts/preinstall" ]]; then
-        cp "$RESOURCES_DIR/scripts/preinstall" "${BUILD_DIR}/scripts/"
-        chmod +x "${BUILD_DIR}/scripts/preinstall"
-        log_success "Copied preinstall script"
-    fi
+    cp "$RESOURCES_DIR/scripts/preinstall" "${BUILD_DIR}/scripts/"
+    chmod +x "${BUILD_DIR}/scripts/preinstall"
 
-    if [[ -f "$RESOURCES_DIR/scripts/postinstall" ]]; then
-        cp "$RESOURCES_DIR/scripts/postinstall" "${BUILD_DIR}/scripts/"
-        chmod +x "${BUILD_DIR}/scripts/postinstall"
-        log_success "Copied postinstall script"
-    fi
+    cp "$RESOURCES_DIR/scripts/postinstall" "${BUILD_DIR}/scripts/"
+    chmod +x "${BUILD_DIR}/scripts/postinstall"
 
-    if [[ -f "$RESOURCES_DIR/scripts/uninstall.sh" ]]; then
-        cp "$RESOURCES_DIR/scripts/uninstall.sh" "${BUILD_DIR}/scripts/"
-        chmod +x "${BUILD_DIR}/scripts/uninstall.sh"
-        log_success "Copied uninstall.sh script"
-    fi
+    cp "$RESOURCES_DIR/scripts/uninstall.sh" "${BUILD_DIR}/scripts/"
+    chmod +x "${BUILD_DIR}/scripts/uninstall.sh"
+
+    log_success "Copied installation scripts"
 }
 
 # Build component package


### PR DESCRIPTION
The preinstall script sources process-control.sh to stop the running app and service before reinstalling, but copy_scripts() never copied it into the build directory. 

Also removed silent if-guards on all required scripts so a missing file fails the build instead of producing a broken installer.