### PR TITLE
fix: Fixes generation of release notes to not rely on existing release

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -56,7 +56,7 @@ jobs:
           organization-url: "https://hopr.zulipchat.com"
           type: "stream"
           to: "GnosisVPN"
-          topic: "Releases"
+          topic: "Snapshot Builds"
           content: ${{ env.NOTIFICATION_CONTENT }}
       - name: Update latest merged PR variables
         env:

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -25,6 +25,7 @@ interface RepoConfig {
   label: string;
   previousVersion: string;
   currentVersion: string;
+  allowMissingRelease: boolean;
 }
 
 interface Config {
@@ -145,7 +146,11 @@ async function ghApiCall(
       }
 
       if (response.status === 404 && allowNotFound) {
-        return null;
+        log(
+           "WARN",
+           `GitHub API returned 404 for optional request /repos/${repo}${endpoint}; treating as not found and continuing with fallback behavior.`,
+         );
+         return null;
       }
 
       if (!response.ok) {
@@ -176,6 +181,8 @@ async function getVersionDate(
   config: Config,
   repo: string,
   version: string,
+  allowMissingRelease: boolean,
+
 ): Promise<string> {
   log("DEBUG", `Fetching version date for ${repo} ${version}`);
   let date = "";
@@ -200,7 +207,7 @@ async function getVersionDate(
   } else if (/^v?\d+\.\d+\.\d+$/.test(`${version}`)) {
     log("DEBUG", `Getting version date from release tag`);
     const tag = `${version}`.replace(/^v/, "");
-    const release = (await ghApiCall(config, repo, `/releases/tags/${tag}`, true)) as GitHubRelease | null;
+    const release = (await ghApiCall(config, repo, `/releases/tags/${tag}`, allowMissingRelease)) as GitHubRelease | null;
     // Release may not exist yet if this is the currentVersion being created in this workflow run.
     date = release?.created_at ?? new Date().toISOString();
   } else {
@@ -558,18 +565,21 @@ function readConfig(): Config {
         label: "Installer",
         previousVersion: previousPackageVersion,
         currentVersion: currentPackageVersion,
+        allowMissingRelease: true, // Allow missing release for installer since it may not be created yet
       },
       {
         repo: "gnosis/gnosis_vpn-client",
         label: "Client",
         previousVersion: previousCliVersion,
         currentVersion: currentCliVersion,
+        allowMissingRelease: false,
       },
       {
         repo: "gnosis/gnosis_vpn-app",
         label: "App",
         previousVersion: previousAppVersion,
         currentVersion: currentAppVersion,
+        allowMissingRelease: false,
       },
     ],
     format: format as Config["format"],
@@ -595,11 +605,11 @@ async function main(): Promise<void> {
   // Fetch PRs from all repositories
   const allEntries: ChangelogEntry[] = [];
 
-  for (const { repo, label, previousVersion, currentVersion } of config.repositories) {
+  for (const { repo, label, previousVersion, currentVersion, allowMissingRelease } of config.repositories) {
     if (previousVersion === currentVersion) continue;
 
-    const previousDate = await getVersionDate(config, repo, previousVersion);
-    const currentDate = await getVersionDate(config, repo, currentVersion);
+    const previousDate = await getVersionDate(config, repo, previousVersion, false);
+    const currentDate = await getVersionDate(config, repo, currentVersion, allowMissingRelease);
     log("INFO", `${label} date range: ${previousDate} to ${currentDate}`);
 
     const entries = await fetchMergedPRs(config, repo, previousDate, currentDate, label, config.branch);

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -64,10 +64,6 @@ interface GitHubCommit {
   };
 }
 
-interface GitHubRelease {
-  created_at: string;
-  tag_name: string;
-}
 
 // --- Logging ---
 
@@ -192,12 +188,8 @@ async function getVersionDate(
     const commitHash = version.split("+commit.")[1];
     const commit = (await ghApiCall(config, repo, `/commits/${commitHash}`)) as GitHubCommit;
     date = commit.commit.committer.date;
-  } else if (/^v?\d+\.\d+\.\d+$/.test(`${version}`)) {
-    log("DEBUG", `Getting version date from release tag`);
-    const tag = `${version}`.replace(/^v/, "");
-    const release = (await ghApiCall(config, repo, `/releases/tags/${tag}`)) as GitHubRelease;
-    date = release.created_at;
   } else {
+    // Plain semver or unknown: use now, since the GitHub release is created after this script runs.
     date = new Date().toISOString();
   }
 
@@ -299,45 +291,6 @@ function zulipFormat(
   return content;
 }
 
-Deno.test("zulipFormat formats nightly snapshot entries and download links", () => {
-  const output = zulipFormat([
-    {
-      id: "123",
-      title: "fix(cli): improve login flow",
-      author: "octocat",
-      repository: "gnosis/gnosis_vpn-client",
-      component: "cli",
-    } as ChangelogEntry,
-  ]);
-
-  if (!output.includes("A new snapshot build is available with the following updates:\n\n")) {
-    throw new Error("zulipFormat output is missing the snapshot intro");
-  }
-
-  if (
-    !output.includes(
-      "- [#123](https://github.com/gnosis/gnosis_vpn-client/pull/123) [cli] fix(cli): improve login flow by octocat\n",
-    )
-  ) {
-    throw new Error("zulipFormat output is missing the expected PR line");
-  }
-
-  if (
-    !output.includes(
-      "- [GnosisVPN Debian x86_64](https://download.gnosisvpn.io/latest/gnosisvpn_amd64.deb)\n",
-    )
-  ) {
-    throw new Error("zulipFormat output is missing the Debian x86_64 download link");
-  }
-
-  if (
-    !output.includes(
-      "Please note that this is a snapshot release intended for testing and may contain unstable features.\n",
-    )
-  ) {
-    throw new Error("zulipFormat output is missing the snapshot warning");
-  }
-});
 function githubFormat(
   entries: ChangelogEntry[],
   previousCliVersion: string,
@@ -795,6 +748,48 @@ Deno.test("getUrgencyLevel - optional for x.y.0 versions", () => {
 Deno.test("getUrgencyLevel - medium for stable patches", () => {
   assertEquals(getUrgencyLevel("1.2.3"), "medium");
   assertEquals(getUrgencyLevel("0.5.1"), "medium");
+});
+
+// --- zulipFormat ---
+
+Deno.test("zulipFormat formats nightly snapshot entries and download links", () => {
+  const output = zulipFormat([
+    {
+      id: "123",
+      title: "fix(cli): improve login flow",
+      author: "octocat",
+      repository: "gnosis/gnosis_vpn-client",
+      component: "cli",
+    } as ChangelogEntry,
+  ]);
+
+  if (!output.includes("A new snapshot build is available with the following updates:\n\n")) {
+    throw new Error("zulipFormat output is missing the snapshot intro");
+  }
+
+  if (
+    !output.includes(
+      "- [#123](https://github.com/gnosis/gnosis_vpn-client/pull/123) [cli] fix(cli): improve login flow by octocat\n",
+    )
+  ) {
+    throw new Error("zulipFormat output is missing the expected PR line");
+  }
+
+  if (
+    !output.includes(
+      "- [GnosisVPN Debian x86_64](https://download.gnosisvpn.io/latest/gnosisvpn_amd64.deb)\n",
+    )
+  ) {
+    throw new Error("zulipFormat output is missing the Debian x86_64 download link");
+  }
+
+  if (
+    !output.includes(
+      "Please note that this is a snapshot release intended for testing and may contain unstable features.\n",
+    )
+  ) {
+    throw new Error("zulipFormat output is missing the snapshot warning");
+  }
 });
 
 // --- githubFormat ---

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -147,10 +147,10 @@ async function ghApiCall(
 
       if (response.status === 404 && allowNotFound) {
         log(
-           "WARN",
-           `GitHub API returned 404 for optional request /repos/${repo}${endpoint}; treating as not found and continuing with fallback behavior.`,
-         );
-         return null;
+          "WARN",
+          `GitHub API returned 404 for optional request /repos/${repo}${endpoint}; treating as not found and continuing with fallback behavior.`,
+        );
+        return null;
       }
 
       if (!response.ok) {
@@ -182,7 +182,6 @@ async function getVersionDate(
   repo: string,
   version: string,
   allowMissingRelease: boolean,
-
 ): Promise<string> {
   log("DEBUG", `Fetching version date for ${repo} ${version}`);
   let date = "";
@@ -207,7 +206,9 @@ async function getVersionDate(
   } else if (/^v?\d+\.\d+\.\d+$/.test(`${version}`)) {
     log("DEBUG", `Getting version date from release tag`);
     const tag = `${version}`.replace(/^v/, "");
-    const release = (await ghApiCall(config, repo, `/releases/tags/${tag}`, allowMissingRelease)) as GitHubRelease | null;
+    const release = (await ghApiCall(config, repo, `/releases/tags/${tag}`, allowMissingRelease)) as
+      | GitHubRelease
+      | null;
     // Release may not exist yet if this is the currentVersion being created in this workflow run.
     date = release?.created_at ?? new Date().toISOString();
   } else {

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -64,6 +64,10 @@ interface GitHubCommit {
   };
 }
 
+interface GitHubRelease {
+  created_at: string;
+  tag_name: string;
+}
 
 // --- Logging ---
 
@@ -91,6 +95,7 @@ async function ghApiCall(
   config: Config,
   repo: string,
   endpoint: string,
+  allowNotFound = false,
 ): Promise<unknown> {
   let attempt = 1;
   let delay = 2000;
@@ -137,6 +142,10 @@ async function ghApiCall(
           attempt++;
           continue;
         }
+      }
+
+      if (response.status === 404 && allowNotFound) {
+        return null;
       }
 
       if (!response.ok) {
@@ -188,8 +197,13 @@ async function getVersionDate(
     const commitHash = version.split("+commit.")[1];
     const commit = (await ghApiCall(config, repo, `/commits/${commitHash}`)) as GitHubCommit;
     date = commit.commit.committer.date;
+  } else if (/^v?\d+\.\d+\.\d+$/.test(`${version}`)) {
+    log("DEBUG", `Getting version date from release tag`);
+    const tag = `${version}`.replace(/^v/, "");
+    const release = (await ghApiCall(config, repo, `/releases/tags/${tag}`, true)) as GitHubRelease | null;
+    // Release may not exist yet if this is the currentVersion being created in this workflow run.
+    date = release?.created_at ?? new Date().toISOString();
   } else {
-    // Plain semver or unknown: use now, since the GitHub release is created after this script runs.
     date = new Date().toISOString();
   }
 


### PR DESCRIPTION
The execution of the `generate-changelog.ts` script relies that the release must exist to get the release date. But in the `release.yaml` workflow the release does not exist yet. So we need to add an edge case and set `now` for that scenario. 