### PR TITLE
fix: Fix the content of the release notes to not reference latest but the specific semver

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -56,6 +56,11 @@ jobs:
             echo "$version+pr.$pr_number"
           }
 
+          get_latest_release_version() {
+            local repo=$1
+            gh api "repos/gnosis/$repo/releases/latest" --jq '.tag_name' | sed 's/^v//'
+          }
+
           LATEST_GNOSISVPN_PACKAGE_PR_VERSION=$(get_latest_pr_version "gnosis_vpn" "package.json")
           LATEST_GNOSISVPN_CLIENT_PR_VERSION=$(get_latest_pr_version "gnosis_vpn-client" "Cargo.toml")
           LATEST_GNOSISVPN_APP_PR_VERSION=$(get_latest_pr_version "gnosis_vpn-app" "src-tauri/Cargo.toml")
@@ -82,9 +87,11 @@ jobs:
               echo "GNOSISVPN_APP_VERSION=${LATEST_GNOSISVPN_APP_PR_VERSION}" | tee -a "$GITHUB_OUTPUT"
               ;;
             release)
+              GNOSISVPN_CLIENT_VERSION=$(get_latest_release_version "gnosis_vpn-client")
+              GNOSISVPN_APP_VERSION=$(get_latest_release_version "gnosis_vpn-app")
               echo "GNOSISVPN_PACKAGE_VERSION=${LATEST_GNOSISVPN_PACKAGE_VERSION_NUMBER}" | tee -a "$GITHUB_OUTPUT"
-              echo "GNOSISVPN_CLIENT_VERSION=latest" | tee -a "$GITHUB_OUTPUT"
-              echo "GNOSISVPN_APP_VERSION=latest" | tee -a "$GITHUB_OUTPUT"
+              echo "GNOSISVPN_CLIENT_VERSION=${GNOSISVPN_CLIENT_VERSION}" | tee -a "$GITHUB_OUTPUT"
+              echo "GNOSISVPN_APP_VERSION=${GNOSISVPN_APP_VERSION}" | tee -a "$GITHUB_OUTPUT"
               ;;
             *)
               echo "Invalid version_type: ${{ inputs.version_type }}. Expected snapshot, commit, pr, or release."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gnosis-vpn",
-  "version": "0.77.1",
+  "version": "0.77.2",
   "description": "Binary artifacts that compose the Gnosis VPN project",
   "license": "LGPL-3.0"
 }


### PR DESCRIPTION
The current implementation was assuming the `latest` version as a valid reference to get the PR of the change log, but that reference is ambiguous when indicating the jump in versions done in the client and app