### PR TITLE
feat: Allow to manual trigger a new Snapshot build

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -1,5 +1,6 @@
 name: Nightly Build
 on:
+  workflow_dispatch:
   repository_dispatch:
     types: [snapshot_build]
   schedule:


### PR DESCRIPTION
Allow to manual trigger a new snapshot build without having to wait to next night build.
This is useful in case the user has forgotten to attach the label `snapshot-build` in any of the PR and they are already merged.