### PR TITLE
feat: Generation of manifests for auto-updater

### DIFF
--- a/.github/workflows/update-manifests.yaml
+++ b/.github/workflows/update-manifests.yaml
@@ -40,7 +40,6 @@ jobs:
         env:
           GNOSISVPN_GPG_PRIVATE_KEY_PATH: /tmp/gnosis_vpn_gpg_key.asc
           GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           OUTPUT_DIR: ./build/manifests
       - name: Prepare manifests for upload
@@ -50,5 +49,5 @@ jobs:
       - name: Publish manifests to bucket
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:
-          path: ./build/bucket
+          path: ./build/manifests/*.json
           destination: download.gnosisvpn.io/manifests

--- a/.github/workflows/update-manifests.yaml
+++ b/.github/workflows/update-manifests.yaml
@@ -35,22 +35,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           OUTPUT_DIR: ./build/manifests
-      - name: Sign manifest linux-amd64
+      - name: Sign manifests
         uses: hoprnet/hopr-workflows/actions/sign-file@sign-file-v2
         with:
-          path: ./build/manifests/linux-amd64.json
-          gpg_private_key: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY }}
-          gpg_private_key_password: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD }}
-      - name: Sign manifest linux-arm64
-        uses: hoprnet/hopr-workflows/actions/sign-file@sign-file-v2
-        with:
-          path: ./build/manifests/linux-arm64.json
-          gpg_private_key: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY }}
-          gpg_private_key_password: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD }}
-      - name: Sign manifest macos-arm64
-        uses: hoprnet/hopr-workflows/actions/sign-file@sign-file-v2
-        with:
-          path: ./build/manifests/macos-arm64.json
+          path: ./build/manifests
           gpg_private_key: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY }}
           gpg_private_key_password: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD }}
       - name: Publish manifests to bucket

--- a/.github/workflows/update-manifests.yaml
+++ b/.github/workflows/update-manifests.yaml
@@ -1,0 +1,49 @@
+name: Update Manifests
+on:
+  workflow_run:
+    workflows:
+      - Close release
+      - Nightly Build
+      - Build
+    types:
+      - completed
+    branches:
+      - main
+concurrency:
+  group: update-manifests
+  cancel-in-progress: false
+jobs:
+  update_manifests:
+    runs-on: depot-ubuntu-22.04-4
+    name: Update Manifests
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'pull_request' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup GCP
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v3
+        with:
+          google_credentials: ${{ secrets.GCP_SA_GITHUB_ACTIONS }}
+          install_sdk: "true"
+      - name: Setup GPG key for signing
+        run: |
+          echo "${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY }}" > /tmp/gnosis_vpn_gpg_key.asc
+          chmod 600 /tmp/gnosis_vpn_gpg_key.asc
+      - name: Generate update manifests
+        run: bash ./scripts/generate-update-manifest.sh
+        env:
+          GNOSISVPN_GPG_PRIVATE_KEY_PATH: /tmp/gnosis_vpn_gpg_key.asc
+          GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          CHANNELS: stable
+          OUTPUT_DIR: ./build/manifests
+      - name: Prepare manifests for upload
+        run: |
+          mkdir -p ./build/bucket
+          cp ./build/manifests/*.json ./build/bucket/
+      - name: Publish manifests to bucket
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
+        with:
+          path: ./build/bucket
+          destination: download.gnosisvpn.io/manifests

--- a/.github/workflows/update-manifests.yaml
+++ b/.github/workflows/update-manifests.yaml
@@ -44,5 +44,5 @@ jobs:
       - name: Publish manifests to bucket
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:
-          path: ./build/manifests/*.json
+          path: ./build/manifests
           destination: download.gnosisvpn.io/manifests

--- a/.github/workflows/update-manifests.yaml
+++ b/.github/workflows/update-manifests.yaml
@@ -26,10 +26,6 @@ jobs:
         with:
           google_credentials: ${{ secrets.GCP_SA_GITHUB_ACTIONS }}
           install_sdk: "true"
-      - name: Setup GPG key for signing
-        run: |
-          echo "${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY }}" > /tmp/gnosis_vpn_gpg_key.asc
-          chmod 600 /tmp/gnosis_vpn_gpg_key.asc
       - name: Install GitHub CLI
         run: |
           sudo apt-get update
@@ -37,10 +33,26 @@ jobs:
       - name: Generate update manifests
         run: bash ./scripts/generate-update-manifest.sh
         env:
-          GNOSISVPN_GPG_PRIVATE_KEY_PATH: /tmp/gnosis_vpn_gpg_key.asc
-          GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD }}
           GH_TOKEN: ${{ github.token }}
           OUTPUT_DIR: ./build/manifests
+      - name: Sign manifest linux-amd64
+        uses: hoprnet/hopr-workflows/actions/sign-file@sign-file-v2
+        with:
+          path: ./build/manifests/linux-amd64.json
+          gpg_private_key: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY }}
+          gpg_private_key_password: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD }}
+      - name: Sign manifest linux-arm64
+        uses: hoprnet/hopr-workflows/actions/sign-file@sign-file-v2
+        with:
+          path: ./build/manifests/linux-arm64.json
+          gpg_private_key: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY }}
+          gpg_private_key_password: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD }}
+      - name: Sign manifest macos-arm64
+        uses: hoprnet/hopr-workflows/actions/sign-file@sign-file-v2
+        with:
+          path: ./build/manifests/macos-arm64.json
+          gpg_private_key: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY }}
+          gpg_private_key_password: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD }}
       - name: Publish manifests to bucket
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:

--- a/.github/workflows/update-manifests.yaml
+++ b/.github/workflows/update-manifests.yaml
@@ -4,7 +4,6 @@ on:
     workflows:
       - Close release
       - Nightly Build
-      - Build
     types:
       - completed
     branches:
@@ -18,7 +17,7 @@ jobs:
     name: Update Manifests
     permissions:
       contents: read
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'pull_request' }}
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -42,10 +41,6 @@ jobs:
           GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD }}
           GH_TOKEN: ${{ github.token }}
           OUTPUT_DIR: ./build/manifests
-      - name: Prepare manifests for upload
-        run: |
-          mkdir -p ./build/bucket
-          cp ./build/manifests/*.json ./build/bucket/
       - name: Publish manifests to bucket
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:

--- a/.github/workflows/update-manifests.yaml
+++ b/.github/workflows/update-manifests.yaml
@@ -16,6 +16,8 @@ jobs:
   update_manifests:
     runs-on: depot-ubuntu-22.04-4
     name: Update Manifests
+    permissions:
+      contents: read
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'pull_request' }}
     steps:
       - name: Checkout repository
@@ -29,6 +31,10 @@ jobs:
         run: |
           echo "${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY }}" > /tmp/gnosis_vpn_gpg_key.asc
           chmod 600 /tmp/gnosis_vpn_gpg_key.asc
+      - name: Install GitHub CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gh
       - name: Generate update manifests
         run: bash ./scripts/generate-update-manifest.sh
         env:
@@ -36,7 +42,6 @@ jobs:
           GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD: ${{ secrets.GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
-          CHANNELS: stable
           OUTPUT_DIR: ./build/manifests
       - name: Prepare manifests for upload
         run: |

--- a/mac/Distribution.xml
+++ b/mac/Distribution.xml
@@ -2,7 +2,7 @@
 <installer-gui-script minSpecVersion="2">
     <title>Gnosis VPN</title>
     <allowed-os-versions>
-        <os-version min="14"/>
+        <os-version min="__MIN_OS_MACOS_MAJOR__"/>
     </allowed-os-versions>
     <organization>com.gnosisvpn</organization>
     <domains enable_anywhere="true"/>

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Shared version constraints — referenced by the manifest generator and macOS installer
 MIN_OS_MACOS="14.0"
-MIN_OS_LINUX="22.04"
+MIN_OS_LINUX_UBUNTU="22.04"
 MIN_APP_VERSION="${MIN_APP_VERSION:-0.77.0}"

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Shared version constraints — referenced by the manifest generator and macOS installer
+MIN_OS_MACOS="14.0"
+MIN_OS_LINUX="22.04"
+MIN_APP_VERSION="${MIN_APP_VERSION:-0.77.0}"

--- a/scripts/generate-package-mac.sh
+++ b/scripts/generate-package-mac.sh
@@ -8,6 +8,8 @@
 
 set -euo pipefail
 
+source "${SCRIPT_DIR}/config.sh"
+
 # Safe default values
 : "${GNOSISVPN_APPLE_CERTIFICATE_DEVELOPER_PATH:=}"
 : "${GNOSISVPN_APPLE_CERTIFICATE_INSTALLER_PATH:=}"
@@ -457,8 +459,12 @@ build_distribution_package() {
         log_warn "welcome.html not found, using default if available"
     fi
 
+    local dist_xml_resolved="${BUILD_DIR}/Distribution.xml"
+    local min_os_major="${MIN_OS_MACOS%%.*}"
+    sed "s/__MIN_OS_MACOS_MAJOR__/${min_os_major}/g" "$DISTRIBUTION_XML" >"$dist_xml_resolved"
+
     productbuild \
-        --distribution "$DISTRIBUTION_XML" \
+        --distribution "$dist_xml_resolved" \
         --resources "$distribution_dir" \
         --package-path "${BUILD_DIR}/packages" \
         --version "$GNOSISVPN_PACKAGE_VERSION" \

--- a/scripts/generate-update-manifest.sh
+++ b/scripts/generate-update-manifest.sh
@@ -28,7 +28,8 @@
 # Channel → data source mapping:
 #   stable    = latest non-prerelease GitHub release
 #   nightly   = latest successful nightly-build workflow run (GitHub Actions artifact)
-#   snapshot  = same as nightly (same workflow, same artifact)
+# TODO ########
+#   snapshot  = TODO when a snapshot workflow is ready
 
 set -euo pipefail
 
@@ -53,7 +54,7 @@ require_env() {
 validate_version() {
     local version="$1"
     # Mirrors check_version_syntax in scripts/common.sh — covers stable (x.y.z),
-    # date-based snapshots (YYYY.MM.DD+build.HHMMSS), and PR/commit builds.
+    # date-based nightly builds (YYYY.MM.DD+build.HHMMSS), and PR/commit builds.
     local semver_regex='^[0-9]+\.[0-9]+\.[0-9]+(\+(pr|commit|build)(\.[0-9A-Za-z-]+)*)?$'
     [[ $version =~ $semver_regex ]] ||
         die "Version '$version' does not match expected format: x.y.z or x.y.z+(pr|commit|build).<meta>"
@@ -96,14 +97,14 @@ get_stable_release_info() {
 }
 
 # Returns "run_id version published_at" for the latest successful nightly build run.
-# Nightly and snapshot builds are GitHub Actions artifacts, not releases.
 # Version is extracted from the Linux amd64 artifact name, which embeds the build timestamp.
-get_snapshot_run_info() {
+get_nightly_run_info() {
     local run_id published_at version
 
     run_id=$(gh run list \
         --repo "$REPO" \
         --workflow "nightly-build.yaml" \
+        --branch main \
         --status success \
         --limit 1 \
         --json databaseId \
@@ -150,7 +151,7 @@ GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD=$(require_env GNOSISVPN_GPG_PRIVATE_KEY_PASSW
 REPO="gnosis/gnosis_vpn"
 require_env GH_TOKEN >/dev/null
 
-CHANNELS="stable nightly snapshot"
+CHANNELS="stable nightly"
 OUTPUT_DIR="${OUTPUT_DIR:-./build/manifests}"
 
 GENERATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -179,11 +180,9 @@ read -r tag version published_at <<<"$(get_stable_release_info)"
 CHANNEL_DATA["stable"]="release $tag $version $published_at"
 echo "  -> release $tag ($version) published $published_at"
 
-echo "Resolving nightly/snapshot channels ..."
-read -r run_id version published_at <<<"$(get_snapshot_run_info)"
-snap_entry="actions $run_id $version $published_at"
-CHANNEL_DATA["nightly"]="$snap_entry"
-CHANNEL_DATA["snapshot"]="$snap_entry"
+echo "Resolving nightly channel ..."
+read -r run_id version published_at <<<"$(get_nightly_run_info)"
+CHANNEL_DATA["nightly"]="actions $run_id $version $published_at"
 echo "  -> actions run $run_id ($version) published $published_at"
 
 # ---------------------------------------------------------------------------

--- a/scripts/generate-update-manifest.sh
+++ b/scripts/generate-update-manifest.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# Generate signed update manifests by querying GitHub releases fresh on every run.
+# No local state — all channel data is fetched directly from GitHub.
+#
+# For each platform/arch the script:
+#   1. Queries GitHub for the latest release per channel.
+#   2. Downloads the pre-computed .sha256 and (where available) .asc files.
+#   3. Reads size_bytes from the GitHub release asset metadata.
+#   4. Builds a manifest containing all channels.
+#   5. Signs the canonical manifest JSON with the GPG key (manifest_signature).
+#   6. Writes the result to OUTPUT_DIR.
+#
+# The .sha256 and .asc files are produced at build time and are the authoritative
+# values — this script never re-downloads or re-hashes the full artifact.
+# Verification uses the public key committed to the repo: gnosisvpn-public-key.asc
+#
+# Required environment variables:
+#   GNOSISVPN_GPG_PRIVATE_KEY_PATH      Path to the ASCII-armored GPG private key file
+#   GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD  Passphrase for the GPG private key
+#   GITHUB_REPOSITORY                   Owner/repo slug (e.g. "gnosis/gnosis_vpn")
+#   GH_TOKEN                            GitHub token with read access to releases
+#
+# Optional environment variables:
+#   CHANNELS              Space-separated channel names to include (default: "stable")
+#                         Supported: stable, nightly, snapshot
+#   OUTPUT_DIR            Where to write manifest JSON files (default: ./build/manifests)
+#   MIN_APP_VERSION       Minimum installed app version eligible for this update (default from config.sh)
+#   MIN_OS_VERSION_LINUX  Override minimum Linux version (default from config.sh)
+#   MIN_OS_VERSION_MACOS  Override minimum macOS version (default from config.sh)
+#
+# Channel → GitHub release mapping:
+#   stable    = latest non-prerelease release
+#   nightly   = latest pre-release with tag matching *nightly*
+#   snapshot  = latest pre-release with tag matching *snapshot*
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+require_env() {
+    local val="${!1:-}"
+    [[ -n $val ]] || die "Required environment variable '$1' is not set or empty."
+    echo "$val"
+}
+
+validate_version() {
+    local version="$1"
+    # Mirrors check_version_syntax in scripts/common.sh — covers stable (x.y.z),
+    # date-based snapshots (YYYY.MM.DD+build.HHMMSS), and PR/commit builds.
+    local semver_regex='^[0-9]+\.[0-9]+\.[0-9]+(\+(pr|commit|build)(\.[0-9A-Za-z-]+)*)?$'
+    [[ $version =~ $semver_regex ]] ||
+        die "Version '$version' does not match expected format: x.y.z or x.y.z+(pr|commit|build).<meta>"
+}
+
+# Sign the canonical (sorted-keys, compact) JSON of a manifest body.
+sign_json_body() {
+    local json="$1"
+    local tmp signature
+    tmp=$(mktemp)
+    printf '%s' "$(echo "$json" | jq -cS .)" >"$tmp"
+    signature=$(
+        printf '%s\n' "$GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD" |
+            gpg --batch --pinentry-mode loopback --passphrase-fd 0 \
+                --detach-sign --output - "$tmp" |
+            base64 | tr -d '\n'
+    )
+    rm -f "$tmp"
+    printf '%s' "$signature"
+}
+
+# Returns "tag published_at" for the latest release matching a channel.
+get_release_info() {
+    local channel="$1"
+    local result
+
+    case "$channel" in
+    stable)
+        result=$(gh release list \
+            --repo "$REPO" \
+            --exclude-pre-releases \
+            --limit 1 \
+            --json tagName,publishedAt |
+            jq -r 'first | "\(.tagName) \(.publishedAt)"')
+        ;;
+    nightly)
+        result=$(gh release list \
+            --repo "$REPO" \
+            --limit 20 \
+            --json tagName,publishedAt,isPrerelease |
+            jq -r '[.[] | select(.isPrerelease and (.tagName | test("nightly")))] | first | "\(.tagName) \(.publishedAt)"')
+        ;;
+    snapshot)
+        result=$(gh release list \
+            --repo "$REPO" \
+            --limit 20 \
+            --json tagName,publishedAt,isPrerelease |
+            jq -r '[.[] | select(.isPrerelease and (.tagName | test("snapshot")))] | first | "\(.tagName) \(.publishedAt)"')
+        ;;
+    *)
+        die "Unknown channel '$channel'. Supported: stable, nightly, snapshot."
+        ;;
+    esac
+
+    [[ -n $result && $result != "null null" ]] ||
+        die "No GitHub release found for channel '$channel'."
+
+    echo "$result"
+}
+
+# ---------------------------------------------------------------------------
+# Platform table: "manifest_name|artifact_template|os_family|default_min_os|has_gpg_sig"
+# Use __VERSION__ as a placeholder for the version string.
+# has_gpg_sig: true for Linux (GPG-signed at build time); false for macOS
+#              (Apple notarization covers integrity there, no .asc produced).
+# ---------------------------------------------------------------------------
+PLATFORMS=(
+    "linux-amd64|gnosisvpn___VERSION___amd64.deb|linux|${MIN_OS_LINUX}|true"
+    "linux-arm64|gnosisvpn___VERSION___arm64.deb|linux|${MIN_OS_LINUX}|true"
+    "macos-arm64|GnosisVPN-Installer-v__VERSION__.pkg|macos|${MIN_OS_MACOS}|false"
+)
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+GPG_KEY_PATH=$(require_env GNOSISVPN_GPG_PRIVATE_KEY_PATH)
+GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD=$(require_env GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD)
+REPO=$(require_env GITHUB_REPOSITORY)
+require_env GH_TOKEN >/dev/null
+
+CHANNELS="${CHANNELS:-stable}"
+OUTPUT_DIR="${OUTPUT_DIR:-./build/manifests}"
+
+GENERATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+mkdir -p "$OUTPUT_DIR"
+
+# Import the GPG key into a temporary keyring; cleaned up on exit.
+GNUPGHOME=$(mktemp -d)
+export GNUPGHOME
+DOWNLOAD_DIRS=()
+trap 'rm -rf "$GNUPGHOME" "${DOWNLOAD_DIRS[@]}"' EXIT
+
+printf '%s\n' "$GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD" |
+    gpg --batch --pinentry-mode loopback --passphrase-fd 0 \
+        --import "$GPG_KEY_PATH"
+
+# ---------------------------------------------------------------------------
+# Step 1: resolve each channel to a GitHub release.
+# ---------------------------------------------------------------------------
+declare -A CHANNEL_DATA
+
+for channel in $CHANNELS; do
+    echo "Resolving channel '$channel' from GitHub ..."
+    read -r tag published_at <<<"$(get_release_info "$channel")"
+    version="${tag#v}"
+    validate_version "$version"
+    echo "  -> $tag ($version) published $published_at"
+    CHANNEL_DATA["$channel"]="$tag $version $published_at"
+done
+
+# ---------------------------------------------------------------------------
+# Step 2: for each platform, build a manifest with all channels.
+# ---------------------------------------------------------------------------
+ERRORS=0
+
+for entry in "${PLATFORMS[@]}"; do
+    IFS='|' read -r MANIFEST_NAME ARTIFACT_TEMPLATE OS_FAMILY DEFAULT_MIN_OS HAS_GPG_SIG <<<"$entry"
+
+    case "$OS_FAMILY" in
+    linux) MIN_OS="${MIN_OS_VERSION_LINUX:-$DEFAULT_MIN_OS}" ;;
+    macos) MIN_OS="${MIN_OS_VERSION_MACOS:-$DEFAULT_MIN_OS}" ;;
+    *) MIN_OS="$DEFAULT_MIN_OS" ;;
+    esac
+
+    echo "Processing platform $MANIFEST_NAME ..."
+
+    CHANNELS_JSON='{}'
+
+    for channel in $CHANNELS; do
+        read -r tag version published_at <<<"${CHANNEL_DATA[$channel]}"
+
+        ARTIFACT_NAME="${ARTIFACT_TEMPLATE//__VERSION__/$version}"
+        DOWNLOAD_DIR=$(mktemp -d)
+        DOWNLOAD_DIRS+=("$DOWNLOAD_DIR")
+
+        echo "  [$channel] Fetching metadata for $ARTIFACT_NAME from release $tag ..."
+
+        # Download the pre-computed hash file (produced at build time).
+        gh release download "$tag" \
+            --repo "$REPO" \
+            --pattern "$ARTIFACT_NAME.sha256" \
+            --dir "$DOWNLOAD_DIR" ||
+            {
+                echo "ERROR: Failed to download $ARTIFACT_NAME.sha256 for channel '$channel'" >&2
+                ERRORS=$((ERRORS + 1))
+                continue
+            }
+
+        SHA256=$(awk '{print $1}' "$DOWNLOAD_DIR/$ARTIFACT_NAME.sha256")
+
+        # Download the GPG detached signature if this platform produces one.
+        if [[ $HAS_GPG_SIG == "true" ]]; then
+            gh release download "$tag" \
+                --repo "$REPO" \
+                --pattern "$ARTIFACT_NAME.asc" \
+                --dir "$DOWNLOAD_DIR" ||
+                {
+                    echo "ERROR: Failed to download $ARTIFACT_NAME.asc for channel '$channel'" >&2
+                    ERRORS=$((ERRORS + 1))
+                    continue
+                }
+            ARTIFACT_SIG=$(base64 <"$DOWNLOAD_DIR/$ARTIFACT_NAME.asc" | tr -d '\n')
+        else
+            ARTIFACT_SIG=""
+        fi
+
+        # Get size_bytes from the release asset metadata — no artifact download needed.
+        if ! SIZE=$(gh release view "$tag" \
+            --repo "$REPO" \
+            --json assets \
+            --jq ".assets[] | select(.name == \"$ARTIFACT_NAME\") | .size"); then
+            echo "ERROR: Failed to fetch asset metadata for '$ARTIFACT_NAME' in release $tag for channel '$channel'" >&2
+            ERRORS=$((ERRORS + 1))
+            continue
+        fi
+
+        [[ -n $SIZE && $SIZE != "null" ]] ||
+            {
+                echo "ERROR: Could not find asset '$ARTIFACT_NAME' in release $tag" >&2
+                ERRORS=$((ERRORS + 1))
+                continue
+            }
+
+        DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${tag}/${ARTIFACT_NAME}"
+        RELEASE_NOTES=$(gh release view "$tag" --repo "$REPO" --json body --jq '.body' 2>/dev/null || echo "")
+
+        CHANNEL_ENTRY=$(jq -n \
+            --arg version "$version" \
+            --arg published_at "$published_at" \
+            --arg download_url "$DOWNLOAD_URL" \
+            --argjson size_bytes "$SIZE" \
+            --arg sha256 "$SHA256" \
+            --arg artifact_signature "$ARTIFACT_SIG" \
+            --arg release_notes "$RELEASE_NOTES" \
+            --arg min_os_version "$MIN_OS" \
+            --arg min_app_version "$MIN_APP_VERSION" \
+            '{
+        version: $version,
+        published_at: $published_at,
+        download_url: $download_url,
+        size_bytes: $size_bytes,
+        sha256: $sha256,
+        artifact_signature: $artifact_signature,
+        release_notes: $release_notes,
+        min_os_version: $min_os_version,
+        min_app_version: $min_app_version
+      }')
+
+        CHANNELS_JSON=$(echo "$CHANNELS_JSON" |
+            jq --arg ch "$channel" --argjson entry "$CHANNEL_ENTRY" \
+                '. + {($ch): $entry}')
+    done
+
+    BODY=$(jq -n \
+        --argjson schema_version 1 \
+        --arg generated_at "$GENERATED_AT" \
+        --argjson channels "$CHANNELS_JSON" \
+        '{schema_version: $schema_version, generated_at: $generated_at, channels: $channels}')
+
+    MANIFEST_SIG=$(sign_json_body "$BODY")
+
+    OUT_PATH="$OUTPUT_DIR/$MANIFEST_NAME.json"
+    echo "$BODY" |
+        jq --arg manifest_signature "$MANIFEST_SIG" \
+            '. + {manifest_signature: $manifest_signature}' \
+            >"$OUT_PATH"
+
+    echo "  Written: $OUT_PATH"
+done
+
+[[ $ERRORS -eq 0 ]] || die "$ERRORS error(s) during manifest generation."
+
+echo "Manifest generation complete."

--- a/scripts/generate-update-manifest.sh
+++ b/scripts/generate-update-manifest.sh
@@ -17,13 +17,12 @@
 # Required environment variables:
 #   GNOSISVPN_GPG_PRIVATE_KEY_PATH      Path to the ASCII-armored GPG private key file
 #   GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD  Passphrase for the GPG private key
-#   GITHUB_REPOSITORY                   Owner/repo slug (e.g. "gnosis/gnosis_vpn")
 #   GH_TOKEN                            GitHub token with read access to releases
 #
 # Optional environment variables:
 #   OUTPUT_DIR            Where to write manifest JSON files (default: ./build/manifests)
 #   MIN_APP_VERSION       Minimum installed app version eligible for this update (default from config.sh)
-#   MIN_OS_VERSION_LINUX  Override minimum Linux version (default from config.sh)
+#   MIN_OS_VERSION_LINUX_UBUNTU  Override minimum Linux version (default from config.sh)
 #   MIN_OS_VERSION_MACOS  Override minimum macOS version (default from config.sh)
 #
 # Channel → data source mapping:
@@ -132,15 +131,14 @@ get_snapshot_run_info() {
 }
 
 # ---------------------------------------------------------------------------
-# Platform table: "manifest_name|artifact_template|os_family|default_min_os|has_gpg_sig"
+# Platform table: "manifest_name|artifact_template|os_family|default_min_os"
 # Use __VERSION__ as a placeholder for the version string.
-# has_gpg_sig: true for Linux (GPG-signed at build time); false for macOS
-#              (Apple notarization covers integrity there, no .asc produced).
+# Linux artifacts are GPG-signed; macOS relies on Apple notarization instead.
 # ---------------------------------------------------------------------------
 PLATFORMS=(
-    "linux-amd64|gnosisvpn___VERSION___amd64.deb|linux|${MIN_OS_LINUX}|true"
-    "linux-arm64|gnosisvpn___VERSION___arm64.deb|linux|${MIN_OS_LINUX}|true"
-    "macos-arm64|GnosisVPN-Installer-v__VERSION__.pkg|macos|${MIN_OS_MACOS}|false"
+    "linux-amd64|gnosisvpn___VERSION___amd64.deb|linux|${MIN_OS_LINUX_UBUNTU}"
+    "linux-arm64|gnosisvpn___VERSION___arm64.deb|linux|${MIN_OS_LINUX_UBUNTU}"
+    "macos-arm64|GnosisVPN-Installer-v__VERSION__.pkg|macos|${MIN_OS_MACOS}"
 )
 
 # ---------------------------------------------------------------------------
@@ -149,7 +147,7 @@ PLATFORMS=(
 
 GPG_KEY_PATH=$(require_env GNOSISVPN_GPG_PRIVATE_KEY_PATH)
 GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD=$(require_env GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD)
-REPO=$(require_env GITHUB_REPOSITORY)
+REPO="gnosis/gnosis_vpn"
 require_env GH_TOKEN >/dev/null
 
 CHANNELS="stable nightly snapshot"
@@ -194,10 +192,10 @@ echo "  -> actions run $run_id ($version) published $published_at"
 ERRORS=0
 
 for entry in "${PLATFORMS[@]}"; do
-    IFS='|' read -r MANIFEST_NAME ARTIFACT_TEMPLATE OS_FAMILY DEFAULT_MIN_OS HAS_GPG_SIG <<<"$entry"
+    IFS='|' read -r MANIFEST_NAME ARTIFACT_TEMPLATE OS_FAMILY DEFAULT_MIN_OS <<<"$entry"
 
     case "$OS_FAMILY" in
-    linux) MIN_OS="${MIN_OS_VERSION_LINUX:-$DEFAULT_MIN_OS}" ;;
+    linux) MIN_OS="${MIN_OS_VERSION_LINUX_UBUNTU:-$DEFAULT_MIN_OS}" ;;
     macos) MIN_OS="${MIN_OS_VERSION_MACOS:-$DEFAULT_MIN_OS}" ;;
     *) MIN_OS="$DEFAULT_MIN_OS" ;;
     esac
@@ -230,7 +228,7 @@ for entry in "${PLATFORMS[@]}"; do
                 }
             SHA256=$(awk '{print $1}' "$DOWNLOAD_DIR/$ARTIFACT_NAME.sha256")
 
-            if [[ $HAS_GPG_SIG == "true" ]]; then
+            if [[ $OS_FAMILY == "linux" ]]; then
                 gh release download "$tag" \
                     --repo "$REPO" \
                     --pattern "$ARTIFACT_NAME.asc" \
@@ -304,7 +302,7 @@ for entry in "${PLATFORMS[@]}"; do
                 }
             SHA256=$(awk '{print $1}' "$DOWNLOAD_DIR/"*.sha256)
 
-            if [[ $HAS_GPG_SIG == "true" ]]; then
+            if [[ $OS_FAMILY == "linux" ]]; then
                 gh run download "$run_id" \
                     --repo "$REPO" \
                     --name "$asc_artifact_name" \

--- a/scripts/generate-update-manifest.sh
+++ b/scripts/generate-update-manifest.sh
@@ -57,7 +57,6 @@ validate_version() {
         die "Version '$version' does not match expected format: x.y.z or x.y.z+(pr|commit|build).<meta>"
 }
 
-
 # Returns "tag version published_at" for the latest stable GitHub release.
 get_stable_release_info() {
     local result

--- a/scripts/generate-update-manifest.sh
+++ b/scripts/generate-update-manifest.sh
@@ -7,8 +7,8 @@
 #   2. Downloads the pre-computed .sha256 and (where available) .asc files.
 #   3. Reads size_bytes from the GitHub release asset metadata.
 #   4. Builds a manifest containing all channels.
-#   5. Signs the canonical manifest JSON with the GPG key (manifest_signature).
-#   6. Writes the result to OUTPUT_DIR.
+#   5. Signs the canonical manifest JSON with the GPG key; writes a detached .asc signature.
+#   6. Writes the manifest JSON and its .asc signature file to OUTPUT_DIR.
 #
 # The .sha256 and .asc files are produced at build time and are the authoritative
 # values — this script never re-downloads or re-hashes the full artifact.
@@ -61,19 +61,17 @@ validate_version() {
 }
 
 # Sign the canonical (sorted-keys, compact) JSON of a manifest body.
-sign_json_body() {
+# Writes a detached ASCII-armored GPG signature to sig_path.
+sign_json_to_file() {
     local json="$1"
-    local tmp signature
+    local sig_path="$2"
+    local tmp
     tmp=$(mktemp)
     printf '%s' "$(echo "$json" | jq -cS .)" >"$tmp"
-    signature=$(
-        printf '%s\n' "$GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD" |
-            gpg --batch --pinentry-mode loopback --passphrase-fd 0 \
-                --detach-sign --output - "$tmp" |
-            base64 | tr -d '\n'
-    )
+    printf '%s\n' "$GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD" |
+        gpg --batch --pinentry-mode loopback --passphrase-fd 0 \
+            --armor --detach-sign --output "$sig_path" "$tmp"
     rm -f "$tmp"
-    printf '%s' "$signature"
 }
 
 # Returns "tag version published_at" for the latest stable GitHub release.
@@ -353,15 +351,14 @@ for entry in "${PLATFORMS[@]}"; do
         --argjson channels "$CHANNELS_JSON" \
         '{schema_version: $schema_version, generated_at: $generated_at, channels: $channels}')
 
-    MANIFEST_SIG=$(sign_json_body "$BODY")
-
     OUT_PATH="$OUTPUT_DIR/$MANIFEST_NAME.json"
-    echo "$BODY" |
-        jq --arg manifest_signature "$MANIFEST_SIG" \
-            '. + {manifest_signature: $manifest_signature}' \
-            >"$OUT_PATH"
+    SIG_PATH="$OUTPUT_DIR/$MANIFEST_NAME.json.asc"
+
+    echo "$BODY" >"$OUT_PATH"
+    sign_json_to_file "$BODY" "$SIG_PATH"
 
     echo "  Written: $OUT_PATH"
+    echo "  Written: $SIG_PATH"
 done
 
 [[ $ERRORS -eq 0 ]] || die "$ERRORS error(s) during manifest generation."

--- a/scripts/generate-update-manifest.sh
+++ b/scripts/generate-update-manifest.sh
@@ -26,10 +26,10 @@
 #   MIN_OS_VERSION_LINUX  Override minimum Linux version (default from config.sh)
 #   MIN_OS_VERSION_MACOS  Override minimum macOS version (default from config.sh)
 #
-# Channel → GitHub release mapping:
-#   stable    = latest non-prerelease release
-#   nightly   = latest pre-release with tag matching *nightly*
-#   snapshot  = latest pre-release with tag matching *snapshot*
+# Channel → data source mapping:
+#   stable    = latest non-prerelease GitHub release
+#   nightly   = latest successful nightly-build workflow run (GitHub Actions artifact)
+#   snapshot  = same as nightly (same workflow, same artifact)
 
 set -euo pipefail
 
@@ -76,43 +76,59 @@ sign_json_body() {
     printf '%s' "$signature"
 }
 
-# Returns "tag published_at" for the latest release matching a channel.
-get_release_info() {
-    local channel="$1"
+# Returns "tag version published_at" for the latest stable GitHub release.
+get_stable_release_info() {
     local result
-
-    case "$channel" in
-    stable)
-        result=$(gh release list \
-            --repo "$REPO" \
-            --exclude-pre-releases \
-            --limit 1 \
-            --json tagName,publishedAt |
-            jq -r 'first | "\(.tagName) \(.publishedAt)"')
-        ;;
-    nightly)
-        result=$(gh release list \
-            --repo "$REPO" \
-            --limit 20 \
-            --json tagName,publishedAt,isPrerelease |
-            jq -r '[.[] | select(.isPrerelease and (.tagName | test("nightly")))] | first | "\(.tagName) \(.publishedAt)"')
-        ;;
-    snapshot)
-        result=$(gh release list \
-            --repo "$REPO" \
-            --limit 20 \
-            --json tagName,publishedAt,isPrerelease |
-            jq -r '[.[] | select(.isPrerelease and (.tagName | test("snapshot")))] | first | "\(.tagName) \(.publishedAt)"')
-        ;;
-    *)
-        die "Unknown channel '$channel'. Supported: stable, nightly, snapshot."
-        ;;
-    esac
+    result=$(gh release list \
+        --repo "$REPO" \
+        --exclude-pre-releases \
+        --limit 1 \
+        --json tagName,publishedAt |
+        jq -r 'first | "\(.tagName) \(.publishedAt)"')
 
     [[ -n $result && $result != "null null" ]] ||
-        die "No GitHub release found for channel '$channel'."
+        die "No stable GitHub release found."
 
-    echo "$result"
+    local tag published_at
+    read -r tag published_at <<<"$result"
+    local version="${tag#v}"
+    validate_version "$version"
+    echo "$tag $version $published_at"
+}
+
+# Returns "run_id version published_at" for the latest successful nightly build run.
+# Nightly and snapshot builds are GitHub Actions artifacts, not releases.
+# Version is extracted from the Linux amd64 artifact name, which embeds the build timestamp.
+get_snapshot_run_info() {
+    local run_id published_at version
+
+    run_id=$(gh run list \
+        --repo "$REPO" \
+        --workflow "nightly-build.yaml" \
+        --status success \
+        --limit 1 \
+        --json databaseId \
+        --jq '.[0].databaseId')
+
+    [[ -n $run_id && $run_id != "null" ]] ||
+        die "No successful nightly-build workflow run found."
+
+    published_at=$(gh run view "$run_id" \
+        --repo "$REPO" \
+        --json createdAt \
+        --jq '.createdAt')
+
+    # All platforms in the run share the same GNOSISVPN_PACKAGE_VERSION.
+    # Extract it from the Linux amd64 artifact name: gnosisvpn_VERSION_amd64.deb
+    version=$(gh api "repos/$REPO/actions/runs/$run_id/artifacts" \
+        --jq '[.artifacts[] | select(.name | test("^gnosisvpn_.*_amd64\\.deb$"))] | first | .name' |
+        sed 's/^gnosisvpn_\(.*\)_amd64\.deb$/\1/')
+
+    [[ -n $version && $version != "null" ]] ||
+        die "Could not determine version from artifacts of run $run_id."
+    validate_version "$version"
+
+    echo "$run_id $version $published_at"
 }
 
 # ---------------------------------------------------------------------------
@@ -154,18 +170,23 @@ printf '%s\n' "$GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD" |
         --import "$GPG_KEY_PATH"
 
 # ---------------------------------------------------------------------------
-# Step 1: resolve each channel to a GitHub release.
+# Step 1: resolve each channel.
+#   CHANNEL_DATA stores "source_type ref version published_at" where source_type
+#   is "release" (ref = git tag) or "actions" (ref = workflow run ID).
 # ---------------------------------------------------------------------------
 declare -A CHANNEL_DATA
 
-for channel in $CHANNELS; do
-    echo "Resolving channel '$channel' from GitHub ..."
-    read -r tag published_at <<<"$(get_release_info "$channel")"
-    version="${tag#v}"
-    validate_version "$version"
-    echo "  -> $tag ($version) published $published_at"
-    CHANNEL_DATA["$channel"]="$tag $version $published_at"
-done
+echo "Resolving stable channel ..."
+read -r tag version published_at <<<"$(get_stable_release_info)"
+CHANNEL_DATA["stable"]="release $tag $version $published_at"
+echo "  -> release $tag ($version) published $published_at"
+
+echo "Resolving nightly/snapshot channels ..."
+read -r run_id version published_at <<<"$(get_snapshot_run_info)"
+snap_entry="actions $run_id $version $published_at"
+CHANNEL_DATA["nightly"]="$snap_entry"
+CHANNEL_DATA["snapshot"]="$snap_entry"
+echo "  -> actions run $run_id ($version) published $published_at"
 
 # ---------------------------------------------------------------------------
 # Step 2: for each platform, build a manifest with all channels.
@@ -186,62 +207,121 @@ for entry in "${PLATFORMS[@]}"; do
     CHANNELS_JSON='{}'
 
     for channel in $CHANNELS; do
-        read -r tag version published_at <<<"${CHANNEL_DATA[$channel]}"
+        read -r source_type ref version published_at <<<"${CHANNEL_DATA[$channel]}"
 
         ARTIFACT_NAME="${ARTIFACT_TEMPLATE//__VERSION__/$version}"
         DOWNLOAD_DIR=$(mktemp -d)
         DOWNLOAD_DIRS+=("$DOWNLOAD_DIR")
 
-        echo "  [$channel] Fetching metadata for $ARTIFACT_NAME from release $tag ..."
+        echo "  [$channel] Fetching metadata for $ARTIFACT_NAME (source: $source_type) ..."
 
-        # Download the pre-computed hash file (produced at build time).
-        gh release download "$tag" \
-            --repo "$REPO" \
-            --pattern "$ARTIFACT_NAME.sha256" \
-            --dir "$DOWNLOAD_DIR" ||
-            {
-                echo "ERROR: Failed to download $ARTIFACT_NAME.sha256 for channel '$channel'" >&2
-                ERRORS=$((ERRORS + 1))
-                continue
-            }
+        if [[ $source_type == "release" ]]; then
+            # ref = git tag; artifacts live in the GitHub release.
+            tag="$ref"
 
-        SHA256=$(awk '{print $1}' "$DOWNLOAD_DIR/$ARTIFACT_NAME.sha256")
-
-        # Download the GPG detached signature if this platform produces one.
-        if [[ $HAS_GPG_SIG == "true" ]]; then
             gh release download "$tag" \
                 --repo "$REPO" \
-                --pattern "$ARTIFACT_NAME.asc" \
+                --pattern "$ARTIFACT_NAME.sha256" \
                 --dir "$DOWNLOAD_DIR" ||
                 {
-                    echo "ERROR: Failed to download $ARTIFACT_NAME.asc for channel '$channel'" >&2
+                    echo "ERROR: Failed to download $ARTIFACT_NAME.sha256 for channel '$channel'" >&2
                     ERRORS=$((ERRORS + 1))
                     continue
                 }
-            ARTIFACT_SIG=$(base64 <"$DOWNLOAD_DIR/$ARTIFACT_NAME.asc" | tr -d '\n')
-        else
-            ARTIFACT_SIG=""
-        fi
+            SHA256=$(awk '{print $1}' "$DOWNLOAD_DIR/$ARTIFACT_NAME.sha256")
 
-        # Get size_bytes from the release asset metadata — no artifact download needed.
-        if ! SIZE=$(gh release view "$tag" \
-            --repo "$REPO" \
-            --json assets \
-            --jq ".assets[] | select(.name == \"$ARTIFACT_NAME\") | .size"); then
-            echo "ERROR: Failed to fetch asset metadata for '$ARTIFACT_NAME' in release $tag for channel '$channel'" >&2
-            ERRORS=$((ERRORS + 1))
-            continue
-        fi
+            if [[ $HAS_GPG_SIG == "true" ]]; then
+                gh release download "$tag" \
+                    --repo "$REPO" \
+                    --pattern "$ARTIFACT_NAME.asc" \
+                    --dir "$DOWNLOAD_DIR" ||
+                    {
+                        echo "ERROR: Failed to download $ARTIFACT_NAME.asc for channel '$channel'" >&2
+                        ERRORS=$((ERRORS + 1))
+                        continue
+                    }
+                ARTIFACT_SIG=$(base64 <"$DOWNLOAD_DIR/$ARTIFACT_NAME.asc" | tr -d '\n')
+            else
+                ARTIFACT_SIG=""
+            fi
 
-        [[ -n $SIZE && $SIZE != "null" ]] ||
-            {
-                echo "ERROR: Could not find asset '$ARTIFACT_NAME' in release $tag" >&2
+            if ! SIZE=$(gh release view "$tag" \
+                --repo "$REPO" \
+                --json assets \
+                --jq ".assets[] | select(.name == \"$ARTIFACT_NAME\") | .size"); then
+                echo "ERROR: Failed to fetch asset metadata for '$ARTIFACT_NAME' in release $tag for channel '$channel'" >&2
                 ERRORS=$((ERRORS + 1))
                 continue
-            }
+            fi
 
-        DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${tag}/${ARTIFACT_NAME}"
-        RELEASE_NOTES=$(gh release view "$tag" --repo "$REPO" --json body --jq '.body' 2>/dev/null || echo "")
+            [[ -n $SIZE && $SIZE != "null" ]] ||
+                {
+                    echo "ERROR: Could not find asset '$ARTIFACT_NAME' in release $tag" >&2
+                    ERRORS=$((ERRORS + 1))
+                    continue
+                }
+
+            DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${tag}/${ARTIFACT_NAME}"
+            RELEASE_NOTES=$(gh release view "$tag" --repo "$REPO" --json body --jq '.body' 2>/dev/null || echo "")
+
+        else
+            # ref = workflow run ID; artifacts live in GitHub Actions.
+            # macOS artifact name is fixed (no version); Linux includes the version.
+            run_id="$ref"
+            case "$OS_FAMILY" in
+            linux)
+                pkg_artifact_name="$ARTIFACT_NAME"
+                sha256_artifact_name="$ARTIFACT_NAME.sha256"
+                asc_artifact_name="$ARTIFACT_NAME.asc"
+                ;;
+            macos)
+                pkg_artifact_name="GnosisVPN-Installer.pkg"
+                sha256_artifact_name="GnosisVPN-Installer.pkg.sha256"
+                ;;
+            esac
+
+            # Fetch artifact metadata (id + size) for the package artifact.
+            ARTIFACT_META=$(gh api "repos/$REPO/actions/runs/$run_id/artifacts" \
+                --jq ".artifacts[] | select(.name == \"$pkg_artifact_name\")")
+            ARTIFACT_ID=$(echo "$ARTIFACT_META" | jq -r '.id')
+            SIZE=$(echo "$ARTIFACT_META" | jq -r '.size_in_bytes')
+
+            [[ -n $ARTIFACT_ID && $ARTIFACT_ID != "null" ]] ||
+                {
+                    echo "ERROR: Artifact '$pkg_artifact_name' not found in run $run_id for channel '$channel'" >&2
+                    ERRORS=$((ERRORS + 1))
+                    continue
+                }
+
+            gh run download "$run_id" \
+                --repo "$REPO" \
+                --name "$sha256_artifact_name" \
+                --dir "$DOWNLOAD_DIR" ||
+                {
+                    echo "ERROR: Failed to download $sha256_artifact_name for channel '$channel'" >&2
+                    ERRORS=$((ERRORS + 1))
+                    continue
+                }
+            SHA256=$(awk '{print $1}' "$DOWNLOAD_DIR/"*.sha256)
+
+            if [[ $HAS_GPG_SIG == "true" ]]; then
+                gh run download "$run_id" \
+                    --repo "$REPO" \
+                    --name "$asc_artifact_name" \
+                    --dir "$DOWNLOAD_DIR" ||
+                    {
+                        echo "ERROR: Failed to download $asc_artifact_name for channel '$channel'" >&2
+                        ERRORS=$((ERRORS + 1))
+                        continue
+                    }
+                ARTIFACT_SIG=$(base64 <"$DOWNLOAD_DIR/$ARTIFACT_NAME.asc" | tr -d '\n')
+            else
+                ARTIFACT_SIG=""
+            fi
+
+            DOWNLOAD_URL="https://api.github.com/repos/${REPO}/actions/artifacts/${ARTIFACT_ID}/zip"
+            RELEASE_NOTES=""
+        fi
 
         CHANNEL_ENTRY=$(jq -n \
             --arg version "$version" \

--- a/scripts/generate-update-manifest.sh
+++ b/scripts/generate-update-manifest.sh
@@ -7,17 +7,14 @@
 #   2. Downloads the pre-computed .sha256 and (where available) .asc files.
 #   3. Reads size_bytes from the GitHub release asset metadata.
 #   4. Builds a manifest containing all channels.
-#   5. Signs the canonical manifest JSON with the GPG key; writes a detached .asc signature.
-#   6. Writes the manifest JSON and its .asc signature file to OUTPUT_DIR.
+#   5. Writes the manifest JSON to OUTPUT_DIR.
 #
 # The .sha256 and .asc files are produced at build time and are the authoritative
 # values — this script never re-downloads or re-hashes the full artifact.
 # Verification uses the public key committed to the repo: gnosisvpn-public-key.asc
 #
 # Required environment variables:
-#   GNOSISVPN_GPG_PRIVATE_KEY_PATH      Path to the ASCII-armored GPG private key file
-#   GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD  Passphrase for the GPG private key
-#   GH_TOKEN                            GitHub token with read access to releases
+#   GH_TOKEN  GitHub token with read access to releases
 #
 # Optional environment variables:
 #   OUTPUT_DIR            Where to write manifest JSON files (default: ./build/manifests)
@@ -60,19 +57,6 @@ validate_version() {
         die "Version '$version' does not match expected format: x.y.z or x.y.z+(pr|commit|build).<meta>"
 }
 
-# Sign the canonical (sorted-keys, compact) JSON of a manifest body.
-# Writes a detached ASCII-armored GPG signature to sig_path.
-sign_json_to_file() {
-    local json="$1"
-    local sig_path="$2"
-    local tmp
-    tmp=$(mktemp)
-    printf '%s' "$(echo "$json" | jq -cS .)" >"$tmp"
-    printf '%s\n' "$GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD" |
-        gpg --batch --pinentry-mode loopback --passphrase-fd 0 \
-            --armor --detach-sign --output "$sig_path" "$tmp"
-    rm -f "$tmp"
-}
 
 # Returns "tag version published_at" for the latest stable GitHub release.
 get_stable_release_info() {
@@ -144,8 +128,6 @@ PLATFORMS=(
 # Main
 # ---------------------------------------------------------------------------
 
-GPG_KEY_PATH=$(require_env GNOSISVPN_GPG_PRIVATE_KEY_PATH)
-GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD=$(require_env GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD)
 REPO="gnosis/gnosis_vpn"
 require_env GH_TOKEN >/dev/null
 
@@ -156,15 +138,8 @@ GENERATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 mkdir -p "$OUTPUT_DIR"
 
-# Import the GPG key into a temporary keyring; cleaned up on exit.
-GNUPGHOME=$(mktemp -d)
-export GNUPGHOME
 DOWNLOAD_DIRS=()
-trap 'rm -rf "$GNUPGHOME" "${DOWNLOAD_DIRS[@]}"' EXIT
-
-printf '%s\n' "$GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD" |
-    gpg --batch --pinentry-mode loopback --passphrase-fd 0 \
-        --import "$GPG_KEY_PATH"
+trap 'rm -rf "${DOWNLOAD_DIRS[@]}"' EXIT
 
 # ---------------------------------------------------------------------------
 # Step 1: resolve each channel.
@@ -352,13 +327,8 @@ for entry in "${PLATFORMS[@]}"; do
         '{schema_version: $schema_version, generated_at: $generated_at, channels: $channels}')
 
     OUT_PATH="$OUTPUT_DIR/$MANIFEST_NAME.json"
-    SIG_PATH="$OUTPUT_DIR/$MANIFEST_NAME.json.asc"
-
     echo "$BODY" >"$OUT_PATH"
-    sign_json_to_file "$BODY" "$SIG_PATH"
-
     echo "  Written: $OUT_PATH"
-    echo "  Written: $SIG_PATH"
 done
 
 [[ $ERRORS -eq 0 ]] || die "$ERRORS error(s) during manifest generation."

--- a/scripts/generate-update-manifest.sh
+++ b/scripts/generate-update-manifest.sh
@@ -21,8 +21,6 @@
 #   GH_TOKEN                            GitHub token with read access to releases
 #
 # Optional environment variables:
-#   CHANNELS              Space-separated channel names to include (default: "stable")
-#                         Supported: stable, nightly, snapshot
 #   OUTPUT_DIR            Where to write manifest JSON files (default: ./build/manifests)
 #   MIN_APP_VERSION       Minimum installed app version eligible for this update (default from config.sh)
 #   MIN_OS_VERSION_LINUX  Override minimum Linux version (default from config.sh)
@@ -138,7 +136,7 @@ GNOSISVPN_GPG_PRIVATE_KEY_PASSWORD=$(require_env GNOSISVPN_GPG_PRIVATE_KEY_PASSW
 REPO=$(require_env GITHUB_REPOSITORY)
 require_env GH_TOKEN >/dev/null
 
-CHANNELS="${CHANNELS:-stable}"
+CHANNELS="stable nightly snapshot"
 OUTPUT_DIR="${OUTPUT_DIR:-./build/manifests}"
 
 GENERATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
Changelog:
- Adds scripts/generate-update-manifest.sh — generates signed JSON manifests (linux-amd64.json, linux-arm64.json, macos-arm64.json) per update channel by querying GitHub releases fresh on every run.
- Uses pre-computed .sha256 and .asc build artifacts instead of re-downloading full packages, ensuring hashes reflect build-time values and can't be influenced by post-publish tampering.
- Reuses existing GNOSISVPN_GPG_PRIVATE_KEY for manifest signing - clients verify with the committed gnosisvpn-public-key.asc.
- New update-manifests.yaml workflow triggers after any successful release/nightly/snapshot and publishes to download.gnosisvpn.io/manifests/ via the existing GCS upload action.