### PR TITLE
fix: GCP omits Content-Length for gzip-transcoded, instead of a HEAD request we now do a full GET

### DIFF
--- a/scripts/generate-update-manifest.sh
+++ b/scripts/generate-update-manifest.sh
@@ -176,7 +176,7 @@ for entry in "${PLATFORMS[@]}"; do
         GCS_URL="${GCS_BASE_URL}/${gcs_prefix}/${GCS_ARTIFACT}"
         echo "  [$channel] Fetching metadata from ${GCS_URL} ..."
 
-        SIZE=$(curl -sk -o /dev/null -w "%{size_download}" "$GCS_URL" || true)
+        SIZE=$(curl -skfL -o /dev/null -w "%{size_download}" "$GCS_URL" || true)
         [[ -n $SIZE ]] ||
             {
                 echo "ERROR: Could not determine size of '${GCS_ARTIFACT}' from ${GCS_URL}" >&2

--- a/scripts/generate-update-manifest.sh
+++ b/scripts/generate-update-manifest.sh
@@ -176,8 +176,7 @@ for entry in "${PLATFORMS[@]}"; do
         GCS_URL="${GCS_BASE_URL}/${gcs_prefix}/${GCS_ARTIFACT}"
         echo "  [$channel] Fetching metadata from ${GCS_URL} ..."
 
-        SIZE=$(curl -skI "$GCS_URL" |
-            grep -i '^content-length:' | awk '{print $2}' | tr -d '\r' || true)
+        SIZE=$(curl -sk -o /dev/null -w "%{size_download}" "$GCS_URL" || true)
         [[ -n $SIZE ]] ||
             {
                 echo "ERROR: Could not determine size of '${GCS_ARTIFACT}' from ${GCS_URL}" >&2


### PR DESCRIPTION
GCP omits Content-Length for gzip-transcoded files served via HTTP/2, so instead of a HEAD request we now do a full GET with -o /dev/null -w "%{size_download}" to get the exact decompressed byte count.