### PR TITLE
fix: upload of the manifests to the gcp

### DIFF
--- a/.github/workflows/update-manifests.yaml
+++ b/.github/workflows/update-manifests.yaml
@@ -19,14 +19,15 @@ jobs:
     permissions:
       contents: read
       actions: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup GCP
         uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v3
         with:
-          google_credentials: ${{ secrets.GCP_SA_GITHUB_ACTIONS }}
-          install_sdk: "true"
+          workload_identity_provider: projects/656686060169/locations/global/workloadIdentityPools/gnosisvpn-gh-pool/providers/github-provider
+          service_account: download-gnosisvpn-gh-sa@gnosisvpn-production.iam.gserviceaccount.com
       - name: Install GitHub CLI
         run: |
           sudo apt-get update
@@ -46,4 +47,4 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         with:
           path: ./build/manifests
-          destination: download.gnosisvpn.io/manifests
+          destination: download.gnosisvpn.io


### PR DESCRIPTION
The download bucket has a specific service account to upload files which is different from the other service accounts used to publish artifacts to Google artifact registry