### PR TITLE
chore: unify apt-repo filenames versioning

### DIFF
--- a/linux/nfpm-template.yaml
+++ b/linux/nfpm-template.yaml
@@ -3,6 +3,8 @@ name: gnosisvpn
 arch: "${NFPM_ARCHITECTURE}"
 platform: linux
 version: "${GNOSISVPN_PACKAGE_VERSION}"
+# None, because 'semver' strips zeros (2026.05.27 -> 2026.5.27)
+version_schema: none
 section: net
 priority: optional
 maintainer: Hoprnet <tech@hoprnet.org>

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -305,17 +305,23 @@ function zulipFormat(
     content +=
       `- [#${entry.id}](https://github.com/${entry.repository}/pull/${entry.id}) [${entry.component}] ${entry.title} by ${entry.author}\n`;
   }
-  content += "\nDownloads:";
+  content += "\nDownload links:";
   if (packageVersion) {
     // macOS .pkg filenames substitute '-' for '+' in the version slug for
     // Artifact Registry compatibility (see build-binary.yaml::prepare_files).
     const macFileSlug = packageVersion.replaceAll("+", "-");
-    content += ` [Mac](https://download.gnosisvpn.io/macos/latest/gnosisvpn_${macFileSlug}_arm64.pkg)`;
+    // Debian .debs live in the snapshot APT pool under their versioned filenames
+    // (gnosisvpn_<version>_<arch>.deb); the version is the literal padded value
+    // emitted by the build (see linux/nfpm-template.yaml version_schema: none).
+    const debPool = "https://download.gnosisvpn.io/linux/apt/pool/snapshot/g/gnosisvpn";
+    content += ` [Mac](https://download.gnosisvpn.io/macos/latest/gnosisvpn_${macFileSlug}_arm64.pkg) |`;
+    content += ` [Debian x86_64](${debPool}/gnosisvpn_${packageVersion}_amd64.deb) |`;
+    content += ` [Debian aarch64](${debPool}/gnosisvpn_${packageVersion}_arm64.deb)\n`;
   } else {
     content += " Mac: see [macos-arm64.json manifest](https://download.gnosisvpn.io/manifests/macos-arm64.json)";
+    content +=
+      " | Debian/Ubuntu: `curl -fsSL https://download.gnosisvpn.io/linux/install.sh | sudo bash -s -- --channel=snapshot`\n";
   }
-  content +=
-    " | Debian/Ubuntu: `curl -fsSL https://download.gnosisvpn.io/linux/install.sh | sudo bash -s -- --channel=snapshot`\n";
   return content;
 }
 
@@ -818,10 +824,18 @@ Deno.test("zulipFormat formats snapshot entries and download links", () => {
 
   if (
     !output.includes(
-      "https://download.gnosisvpn.io/linux/install.sh",
+      "[Debian x86_64](https://download.gnosisvpn.io/linux/apt/pool/snapshot/g/gnosisvpn/gnosisvpn_2026.05.14+build.143052_amd64.deb)",
     )
   ) {
-    throw new Error("zulipFormat output is missing the Linux install command");
+    throw new Error("zulipFormat output is missing the Debian x86_64 apt-pool link");
+  }
+
+  if (
+    !output.includes(
+      "[Debian aarch64](https://download.gnosisvpn.io/linux/apt/pool/snapshot/g/gnosisvpn/gnosisvpn_2026.05.14+build.143052_arm64.deb)",
+    )
+  ) {
+    throw new Error("zulipFormat output is missing the Debian aarch64 apt-pool link");
   }
 });
 


### PR DESCRIPTION
Added version_schema: none to linux/nfpm-template.yaml:8. This tells nfpm to write the version literally instead of normalizing it as semver, so the control Version stays 2026.05.27+build.HHMMSS (zero-padded). reprepro then names the pool .deb from that padded version, matching the .asc/.sha256 sidecars and the URL that generate-update-manifest constructs.

Currently we have:
<img width="265" height="192" alt="image" src="https://github.com/user-attachments/assets/ff000738-ae03-4d99-9704-002a6bf560db" />


Also, birng back the original download links to zullip
