### PR TITLE
fix: resolving manifest version, fail release if the tag already exists, real release notes

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -87,9 +87,17 @@ jobs:
               echo "GNOSISVPN_APP_VERSION=${LATEST_GNOSISVPN_APP_PR_VERSION}" | tee -a "$GITHUB_OUTPUT"
               ;;
             release)
+              # Read package.json from the ref the workflow was dispatched on
+              # (typically main, but supports release branches). The hopr-workflows
+              # release-version action also reads source_branch's package.json, so
+              # sourcing it here keeps the build version and the release version
+              # aligned regardless of which branch close-release runs on.
+              GNOSISVPN_PACKAGE_VERSION=$(gh api \
+                "repos/${{ github.repository }}/contents/package.json?ref=${{ github.ref }}" \
+                --jq '.content' | base64 --decode | jq -r '.version')
               GNOSISVPN_CLIENT_VERSION=$(get_latest_release_version "gnosis_vpn-client")
               GNOSISVPN_APP_VERSION=$(get_latest_release_version "gnosis_vpn-app")
-              echo "GNOSISVPN_PACKAGE_VERSION=${LATEST_GNOSISVPN_PACKAGE_VERSION_NUMBER}" | tee -a "$GITHUB_OUTPUT"
+              echo "GNOSISVPN_PACKAGE_VERSION=${GNOSISVPN_PACKAGE_VERSION}" | tee -a "$GITHUB_OUTPUT"
               echo "GNOSISVPN_CLIENT_VERSION=${GNOSISVPN_CLIENT_VERSION}" | tee -a "$GITHUB_OUTPUT"
               echo "GNOSISVPN_APP_VERSION=${GNOSISVPN_APP_VERSION}" | tee -a "$GITHUB_OUTPUT"
               ;;

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,6 +64,12 @@ jobs:
           GNOSISVPN_PREVIOUS_CLIENT_VERSION: ${{ vars.GNOSISVPN_CLIENT_RELEASE_VERSION }}
           GNOSISVPN_PREVIOUS_APP_VERSION: ${{ vars.GNOSISVPN_APP_RELEASE_VERSION }}
           GNOSISVPN_CHANGELOG_FORMAT: github
+          # Aggregate PRs merged into the dispatching ref (e.g. a release branch)
+          # rather than main, so close-release on a non-main branch produces release
+          # notes that match what actually shipped on that branch. Only affects the
+          # gnosis_vpn (installer) repo lookup; client/app PRs are aggregated from
+          # their own repos with the default branch.
+          GNOSISVPN_BRANCH: ${{ github.ref_name }}
       - name: Release version
         uses: hoprnet/hopr-workflows/actions/release-version@2cae201c4f92e86cf40480704bdc5c2d53bce772 # release-version-v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,7 +69,7 @@ jobs:
           # notes that match what actually shipped on that branch. Only affects the
           # gnosis_vpn (installer) repo lookup; client/app PRs are aggregated from
           # their own repos with the default branch.
-          GNOSISVPN_BRANCH: ${{ github.ref_name }}
+          GNOSISVPN_PACKAGE_BRANCH: ${{ github.ref_name }}
       - name: Release version
         uses: hoprnet/hopr-workflows/actions/release-version@2cae201c4f92e86cf40480704bdc5c2d53bce772 # release-version-v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Verify tag does not already exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GNOSISVPN_PACKAGE_VERSION: ${{ needs.build_binary.outputs.GNOSISVPN_PACKAGE_VERSION }}
+        run: |
+          tag="v${GNOSISVPN_PACKAGE_VERSION}"
+          if gh api "repos/${{ github.repository }}/git/refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "ERROR: tag ${tag} already exists — refusing to re-release." >&2
+            echo "Bump package.json or delete the existing tag/release manually before retrying." >&2
+            exit 1
+          fi
+          echo "Tag ${tag} does not exist — proceeding."
       - name: Setup Nix
         uses: hoprnet/hopr-workflows/actions/setup-nix@c8d45034bb33307dfda3b4dfcd1fc4000cadc05a # setup-nix-v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,18 +31,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Verify tag does not already exist
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GNOSISVPN_PACKAGE_VERSION: ${{ needs.build_binary.outputs.GNOSISVPN_PACKAGE_VERSION }}
-        run: |
-          tag="v${GNOSISVPN_PACKAGE_VERSION}"
-          if gh api "repos/${{ github.repository }}/git/refs/tags/${tag}" >/dev/null 2>&1; then
-            echo "ERROR: tag ${tag} already exists — refusing to re-release." >&2
-            echo "Bump package.json or delete the existing tag/release manually before retrying." >&2
-            exit 1
-          fi
-          echo "Tag ${tag} does not exist — proceeding."
       - name: Setup Nix
         uses: hoprnet/hopr-workflows/actions/setup-nix@c8d45034bb33307dfda3b4dfcd1fc4000cadc05a # setup-nix-v1
         with:

--- a/.github/workflows/snapshot-build.yaml
+++ b/.github/workflows/snapshot-build.yaml
@@ -79,3 +79,16 @@ jobs:
             echo "New merged PR found for gnosis_vpn-app: ${GNOSISVPN_APP_VERSION}"
             gh variable set GNOSISVPN_APP_PR_VERSION --repo ${{ github.repository }} --body "${GNOSISVPN_APP_VERSION}"
           fi
+      - name: Publish snapshot manifest variables
+        # This job only runs when artifacts were actually built
+        # (SNAPSHOT_TRIGGERED == 'true'), so these variables always reflect the
+        # most recent real snapshot — never a no-op skipped run. generate-update-manifest.sh
+        # reads them instead of walking workflow runs to find the latest non-skipped build.
+        env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GNOSISVPN_SNAPSHOT_VERSION: ${{ needs.build_binary.outputs.GNOSISVPN_PACKAGE_VERSION }}
+        run: |
+          published_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo "Publishing snapshot version ${GNOSISVPN_SNAPSHOT_VERSION} (published_at ${published_at})"
+          gh variable set GNOSISVPN_SNAPSHOT_VERSION --repo ${{ github.repository }} --body "${GNOSISVPN_SNAPSHOT_VERSION}"
+          gh variable set GNOSISVPN_SNAPSHOT_DATE --repo ${{ github.repository }} --body "${published_at}"

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -23,6 +23,10 @@
 interface RepoConfig {
   repo: string;
   label: string;
+  // PR `base=` filter. Defaults to "main"; the installer repo is overridable
+  // via GNOSISVPN_BRANCH so close-release on a release branch only includes
+  // installer PRs that targeted that branch.
+  branch: string;
   previousVersion: string;
   currentVersion: string;
   allowMissingRelease: boolean;
@@ -31,7 +35,6 @@ interface RepoConfig {
 interface Config {
   repositories: RepoConfig[];
   format: "zulip" | "github" | "debian" | "json" | "rpm";
-  branch: string;
   ghApiMaxAttempts: number;
   ghToken: string;
 }
@@ -576,6 +579,7 @@ function readConfig(): Config {
       {
         repo: "gnosis/gnosis_vpn",
         label: "Installer",
+        branch: Deno.env.get("GNOSISVPN_BRANCH") || "main",
         previousVersion: previousPackageVersion,
         currentVersion: currentPackageVersion,
         allowMissingRelease: true, // Allow missing release for installer since it may not be created yet
@@ -583,6 +587,7 @@ function readConfig(): Config {
       {
         repo: "gnosis/gnosis_vpn-client",
         label: "Client",
+        branch: "main",
         previousVersion: previousCliVersion,
         currentVersion: currentCliVersion,
         allowMissingRelease: false,
@@ -590,13 +595,13 @@ function readConfig(): Config {
       {
         repo: "gnosis/gnosis_vpn-app",
         label: "App",
+        branch: "main",
         previousVersion: previousAppVersion,
         currentVersion: currentAppVersion,
         allowMissingRelease: false,
       },
     ],
     format: format as Config["format"],
-    branch: Deno.env.get("GNOSISVPN_BRANCH") || "main",
     ghApiMaxAttempts: parseInt(Deno.env.get("GH_API_MAX_ATTEMPTS") || "6", 10),
     ghToken,
   };
@@ -608,24 +613,23 @@ async function main(): Promise<void> {
   const config = readConfig();
 
   console.error("Generating release notes...");
-  for (const { label, previousVersion, currentVersion } of config.repositories) {
-    console.error(`  ${label}: ${previousVersion} -> ${currentVersion}`);
+  for (const { label, previousVersion, currentVersion, branch } of config.repositories) {
+    console.error(`  ${label}: ${previousVersion} -> ${currentVersion} (base: ${branch})`);
   }
   console.error(`  Format: ${config.format}`);
-  console.error(`  Branch: ${config.branch}`);
   console.error("");
 
   // Fetch PRs from all repositories
   const allEntries: ChangelogEntry[] = [];
 
-  for (const { repo, label, previousVersion, currentVersion, allowMissingRelease } of config.repositories) {
+  for (const { repo, label, branch, previousVersion, currentVersion, allowMissingRelease } of config.repositories) {
     if (previousVersion === currentVersion) continue;
 
     const previousDate = await getVersionDate(config, repo, previousVersion, false);
     const currentDate = await getVersionDate(config, repo, currentVersion, allowMissingRelease);
     log("INFO", `${label} date range: ${previousDate} to ${currentDate}`);
 
-    const entries = await fetchMergedPRs(config, repo, previousDate, currentDate, label, config.branch);
+    const entries = await fetchMergedPRs(config, repo, previousDate, currentDate, label, branch);
     allEntries.push(...entries);
   }
 

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -24,7 +24,7 @@ interface RepoConfig {
   repo: string;
   label: string;
   // PR `base=` filter. Defaults to "main"; the installer repo is overridable
-  // via GNOSISVPN_BRANCH so close-release on a release branch only includes
+  // via GNOSISVPN_PACKAGE_BRANCH so close-release on a release branch only includes
   // installer PRs that targeted that branch.
   branch: string;
   previousVersion: string;
@@ -579,7 +579,7 @@ function readConfig(): Config {
       {
         repo: "gnosis/gnosis_vpn",
         label: "Installer",
-        branch: Deno.env.get("GNOSISVPN_BRANCH") || "main",
+        branch: Deno.env.get("GNOSISVPN_PACKAGE_BRANCH") || "main",
         previousVersion: previousPackageVersion,
         currentVersion: currentPackageVersion,
         allowMissingRelease: true, // Allow missing release for installer since it may not be created yet

--- a/scripts/generate-update-manifest.sh
+++ b/scripts/generate-update-manifest.sh
@@ -76,45 +76,19 @@ get_stable_release_info() {
     echo "$tag $version $published_at"
 }
 
-# Returns "version published_at" for the latest snapshot build that actually
-# produced artifacts. snapshot-build skips its build jobs when no new PRs have
-# merged since the previous snapshot (see build-binary.yaml SKIP_BUILDING),
-# yet the run still concludes as "success" — so we walk newest-first and pick
-# the first run whose artifacts include gnosisvpn_*_amd64.deb.
+# Returns "version published_at" for the latest snapshot, read from repository
+# variables that snapshot-build.yaml writes only when it actually produces
+# artifacts — so they always reflect a real snapshot, never a no-op skipped run.
 get_snapshot_run_info() {
-    local run_ids run_id published_at version=""
+    local version published_at
+    version=$(gh variable get GNOSISVPN_SNAPSHOT_VERSION --repo "$REPO")
+    published_at=$(gh variable get GNOSISVPN_SNAPSHOT_DATE --repo "$REPO")
 
-    mapfile -t run_ids < <(gh run list \
-        --repo "$REPO" \
-        --workflow "snapshot-build.yaml" \
-        --branch main \
-        --status success \
-        --limit 20 \
-        --json databaseId \
-        --jq '.[].databaseId')
-
-    [[ ${#run_ids[@]} -gt 0 ]] ||
-        die "No successful snapshot-build workflow run found."
-
-    # All platforms in the run share the same GNOSISVPN_PACKAGE_VERSION.
-    # Extract it from the Linux amd64 artifact name: gnosisvpn_VERSION_amd64.deb
-    for run_id in "${run_ids[@]}"; do
-        version=$(gh api "repos/$REPO/actions/runs/$run_id/artifacts" \
-            --jq '[.artifacts[] | select(.name | test("^gnosisvpn_.*_amd64\\.deb$"))] | first | .name' |
-            sed 's/^gnosisvpn_\(.*\)_amd64\.deb$/\1/')
-        if [[ -n $version && $version != "null" ]]; then
-            break
-        fi
-    done
-
-    [[ -n $version && $version != "null" ]] ||
-        die "No snapshot-build run with a gnosisvpn_*_amd64.deb artifact found in the last ${#run_ids[@]} successful runs."
+    [[ -n $version ]] ||
+        die "Repository variable GNOSISVPN_SNAPSHOT_VERSION is empty — has snapshot-build.yaml published a snapshot yet?"
+    [[ -n $published_at ]] ||
+        die "Repository variable GNOSISVPN_SNAPSHOT_DATE is empty — has snapshot-build.yaml published a snapshot yet?"
     validate_version "$version"
-
-    published_at=$(gh run view "$run_id" \
-        --repo "$REPO" \
-        --json createdAt \
-        --jq '.createdAt')
 
     echo "$version $published_at"
 }

--- a/scripts/generate-update-manifest.sh
+++ b/scripts/generate-update-manifest.sh
@@ -76,37 +76,45 @@ get_stable_release_info() {
     echo "$tag $version $published_at"
 }
 
-# Returns "version published_at" for the latest successful snapshot build.
-# Version is extracted from the Linux amd64 artifact name, which embeds the build timestamp.
+# Returns "version published_at" for the latest snapshot build that actually
+# produced artifacts. snapshot-build skips its build jobs when no new PRs have
+# merged since the previous snapshot (see build-binary.yaml SKIP_BUILDING),
+# yet the run still concludes as "success" — so we walk newest-first and pick
+# the first run whose artifacts include gnosisvpn_*_amd64.deb.
 get_snapshot_run_info() {
-    local run_id published_at version
+    local run_ids run_id published_at version=""
 
-    run_id=$(gh run list \
+    mapfile -t run_ids < <(gh run list \
         --repo "$REPO" \
         --workflow "snapshot-build.yaml" \
         --branch main \
         --status success \
-        --limit 1 \
+        --limit 20 \
         --json databaseId \
-        --jq '.[0].databaseId')
+        --jq '.[].databaseId')
 
-    [[ -n $run_id && $run_id != "null" ]] ||
+    [[ ${#run_ids[@]} -gt 0 ]] ||
         die "No successful snapshot-build workflow run found."
+
+    # All platforms in the run share the same GNOSISVPN_PACKAGE_VERSION.
+    # Extract it from the Linux amd64 artifact name: gnosisvpn_VERSION_amd64.deb
+    for run_id in "${run_ids[@]}"; do
+        version=$(gh api "repos/$REPO/actions/runs/$run_id/artifacts" \
+            --jq '[.artifacts[] | select(.name | test("^gnosisvpn_.*_amd64\\.deb$"))] | first | .name' |
+            sed 's/^gnosisvpn_\(.*\)_amd64\.deb$/\1/')
+        if [[ -n $version && $version != "null" ]]; then
+            break
+        fi
+    done
+
+    [[ -n $version && $version != "null" ]] ||
+        die "No snapshot-build run with a gnosisvpn_*_amd64.deb artifact found in the last ${#run_ids[@]} successful runs."
+    validate_version "$version"
 
     published_at=$(gh run view "$run_id" \
         --repo "$REPO" \
         --json createdAt \
         --jq '.createdAt')
-
-    # All platforms in the run share the same GNOSISVPN_PACKAGE_VERSION.
-    # Extract it from the Linux amd64 artifact name: gnosisvpn_VERSION_amd64.deb
-    version=$(gh api "repos/$REPO/actions/runs/$run_id/artifacts" \
-        --jq '[.artifacts[] | select(.name | test("^gnosisvpn_.*_amd64\\.deb$"))] | first | .name' |
-        sed 's/^gnosisvpn_\(.*\)_amd64\.deb$/\1/')
-
-    [[ -n $version && $version != "null" ]] ||
-        die "Could not determine version from artifacts of run $run_id."
-    validate_version "$version"
 
     echo "$version $published_at"
 }


### PR DESCRIPTION
1. fix: skip no-op snapshot runs when resolving manifest version

snapshot-build short-circuits via SKIP_BUILDING when no new PRs have
merged, but the run still concludes as "success" with no artifacts.
generate-update-manifest.sh was picking up these empty runs and failing.
Walk the 20 most recent successful runs newest-first and pick the first
one that actually has a gnosisvpn_*_amd64.deb artifact.

2. fail release if the tag already exists

3. resolve release version from dispatching ref, not main's latest PR

4. real release notes from provided ref, not main branch