### PR TITLE
chore: change token for manifests

### DIFF
--- a/.github/workflows/update-manifests.yaml
+++ b/.github/workflows/update-manifests.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Generate update manifests
         run: bash ./scripts/generate-update-manifest.sh
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
           OUTPUT_DIR: ./build/manifests
       - name: Sign manifests
         uses: hoprnet/hopr-workflows/actions/sign-file@7bfd6309e663ce6f3a80b3f5a8a2eb4ae9d20108 # sign-file-v2


### PR DESCRIPTION
In update-manifests.yaml, the manifest-generation step ran with GH_TOKEN: ${{ github.token }}. The script's get_snapshot_run_info() (generate-update-manifest.sh:82-94) reads the Actions repository variables GNOSISVPN_SNAPSHOT_VERSION / GNOSISVPN_SNAPSHOT_DATE via gh variable get. The default GITHUB_TOKEN cannot access the Actions variables API at all