### PR TITLE
fix: allow wg-quick to read GnosisVPN config under AppArmor on Ubuntu 26.04

### DIFF
--- a/linux/nfpm-template.yaml
+++ b/linux/nfpm-template.yaml
@@ -120,6 +120,16 @@ contents:
       mode: 0644
       owner: root
       group: root
+  # AppArmor local drop-in: grants the wg-quick profile (Ubuntu 26.04+) read
+  # access to our managed WireGuard config. Plain content (no type: config) so
+  # it is removed cleanly on uninstall; postinstall/postuninstall reparse the
+  # wg-quick profile to pick up / drop this local include.
+  - src: ./linux/resources/apparmor-local-wg-quick
+    dst: /etc/apparmor.d/local/wg-quick
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
   # Shell completions
   - src: ./build/completions/gnosis_vpn-ctl.bash
     dst: /usr/share/bash-completion/completions/gnosis_vpn-ctl

--- a/linux/resources/apparmor-local-wg-quick
+++ b/linux/resources/apparmor-local-wg-quick
@@ -1,0 +1,4 @@
+# Allow wg-quick to read the GnosisVPN-managed WireGuard config.
+# Ubuntu 26.04's wireguard-tools ships an enforcing 'wg-quick' AppArmor profile
+# that otherwise only permits /etc/wireguard/. See gnosisvpn postinstall.sh.
+/var/lib/gnosisvpn/.cache/wg0_gnosisvpn.conf r,

--- a/linux/resources/lintian-overrides
+++ b/linux/resources/lintian-overrides
@@ -5,3 +5,7 @@ gnosisvpn: embedded-library libyaml usr/bin/gnosis_vpn-worker
 
 # Tauri app bundles assets in /usr/lib/<app-name>/ - this is standard for Tauri applications
 gnosisvpn: image-file-in-usr-lib usr/lib/Gnosis VPN/icons/tray-icon.png
+
+# AppArmor local drop-in is intentionally a plain file (not a conffile) so it is
+# removed cleanly on uninstall; postinstall/postuninstall reparse the wg-quick profile.
+gnosisvpn: file-in-etc-not-marked-as-conffile etc/apparmor.d/local/wg-quick

--- a/linux/scripts/postinstall.sh
+++ b/linux/scripts/postinstall.sh
@@ -143,12 +143,12 @@ reload_apparmor_wg_quick() {
         return 0
     fi
     # Skip if AppArmor isn't actually enabled in the kernel.
-    if [[ -r /sys/module/apparmor/parameters/enabled ]] \
-        && [[ "$(cat /sys/module/apparmor/parameters/enabled)" != "Y" ]]; then
+    if [[ -r /sys/module/apparmor/parameters/enabled ]] &&
+        [[ "$(cat /sys/module/apparmor/parameters/enabled)" != "Y" ]]; then
         return 0
     fi
     echo "$LOG_PREFIX INFO: reloading wg-quick AppArmor profile to allow GnosisVPN config..."
-    apparmor_parser -r -T -W /etc/apparmor.d/wg-quick || \
+    apparmor_parser -r -T -W /etc/apparmor.d/wg-quick ||
         echo "$LOG_PREFIX WARNING: failed to reload wg-quick AppArmor profile"
 }
 

--- a/linux/scripts/postinstall.sh
+++ b/linux/scripts/postinstall.sh
@@ -129,6 +129,29 @@ EOF
     echo "$LOG_PREFIX INFO: Run 'sudo apt-get update' to refresh the package cache"
 }
 
+# Reload the wg-quick AppArmor profile so it picks up our local drop-in
+# (/etc/apparmor.d/local/wg-quick), which grants read access to the GnosisVPN
+# WireGuard config under /var/lib/gnosisvpn/.cache/. No-op where the profile or
+# AppArmor isn't present (RPM/Arch/older Ubuntu/AppArmor-disabled).
+reload_apparmor_wg_quick() {
+    # Only relevant where the wg-quick AppArmor profile exists (e.g. Ubuntu 26.04+).
+    if [[ ! -e /etc/apparmor.d/wg-quick ]]; then
+        echo "$LOG_PREFIX INFO: no wg-quick AppArmor profile present, skipping reload"
+        return 0
+    fi
+    if ! command -v apparmor_parser >/dev/null 2>&1; then
+        return 0
+    fi
+    # Skip if AppArmor isn't actually enabled in the kernel.
+    if [[ -r /sys/module/apparmor/parameters/enabled ]] \
+        && [[ "$(cat /sys/module/apparmor/parameters/enabled)" != "Y" ]]; then
+        return 0
+    fi
+    echo "$LOG_PREFIX INFO: reloading wg-quick AppArmor profile to allow GnosisVPN config..."
+    apparmor_parser -r -T -W /etc/apparmor.d/wg-quick || \
+        echo "$LOG_PREFIX WARNING: failed to reload wg-quick AppArmor profile"
+}
+
 # Enable and start the systemd service
 enable_and_start_systemd_service() {
     echo "$LOG_PREFIX INFO: Setting up systemd service..."
@@ -248,6 +271,7 @@ main() {
     create_system_user_and_group
     configure_filesystem_permissions
     register_apt_repo
+    reload_apparmor_wg_quick
     enable_and_start_systemd_service
     install_desktop_shortcut_for_user
 

--- a/linux/scripts/postuninstall.sh
+++ b/linux/scripts/postuninstall.sh
@@ -43,12 +43,12 @@ reload_apparmor_wg_quick() {
         return 0
     fi
     # Skip if AppArmor isn't actually enabled in the kernel.
-    if [[ -r /sys/module/apparmor/parameters/enabled ]] \
-        && [[ "$(cat /sys/module/apparmor/parameters/enabled)" != "Y" ]]; then
+    if [[ -r /sys/module/apparmor/parameters/enabled ]] &&
+        [[ "$(cat /sys/module/apparmor/parameters/enabled)" != "Y" ]]; then
         return 0
     fi
     echo "$LOG_PREFIX INFO: reloading wg-quick AppArmor profile after drop-in removal..."
-    apparmor_parser -r -T -W /etc/apparmor.d/wg-quick || \
+    apparmor_parser -r -T -W /etc/apparmor.d/wg-quick ||
         echo "$LOG_PREFIX WARNING: failed to reload wg-quick AppArmor profile"
 }
 reload_apparmor_wg_quick

--- a/linux/scripts/postuninstall.sh
+++ b/linux/scripts/postuninstall.sh
@@ -31,6 +31,28 @@ fi
 echo "$LOG_PREFIX INFO: Reloading systemd daemon..."
 deb-systemd-helper daemon-reload || true
 
+# Reparse the wg-quick AppArmor profile so the now-removed local drop-in
+# (/etc/apparmor.d/local/wg-quick) include is dropped. No-op where the profile or
+# AppArmor isn't present (RPM/Arch/older Ubuntu/AppArmor-disabled).
+reload_apparmor_wg_quick() {
+    # Only relevant where the wg-quick AppArmor profile exists (e.g. Ubuntu 26.04+).
+    if [[ ! -e /etc/apparmor.d/wg-quick ]]; then
+        return 0
+    fi
+    if ! command -v apparmor_parser >/dev/null 2>&1; then
+        return 0
+    fi
+    # Skip if AppArmor isn't actually enabled in the kernel.
+    if [[ -r /sys/module/apparmor/parameters/enabled ]] \
+        && [[ "$(cat /sys/module/apparmor/parameters/enabled)" != "Y" ]]; then
+        return 0
+    fi
+    echo "$LOG_PREFIX INFO: reloading wg-quick AppArmor profile after drop-in removal..."
+    apparmor_parser -r -T -W /etc/apparmor.d/wg-quick || \
+        echo "$LOG_PREFIX WARNING: failed to reload wg-quick AppArmor profile"
+}
+reload_apparmor_wg_quick
+
 # Check if this is a complete purge
 IS_PURGE=false
 case "$PKG_MANAGER" in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gnosis-vpn",
-  "version": "0.79.2",
+  "version": "0.79.3",
   "description": "Binary artifacts and installer generation scripts that compose the Gnosis VPN project",
   "license": "LGPL-3.0"
 }


### PR DESCRIPTION
fix: allow wg-quick to read GnosisVPN config under AppArmor on Ubuntu 26.04
and a version  [bump due to publish from another branch