### PR TITLE
fix: remove NumberOfProcesses launchd limit to fix EAGAIN on macOS

### DIFF
--- a/mac/resources/config/system/com.gnosisvpn.gnosisvpnclient.plist
+++ b/mac/resources/config/system/com.gnosisvpn.gnosisvpnclient.plist
@@ -82,16 +82,12 @@
     <dict>
         <key>NumberOfFiles</key>
         <integer>1024</integer>
-        <key>NumberOfProcesses</key>
-        <integer>100</integer>
     </dict>
 
     <key>SoftResourceLimits</key>
     <dict>
         <key>NumberOfFiles</key>
         <integer>512</integer>
-        <key>NumberOfProcesses</key>
-        <integer>50</integer>
     </dict>
 
     <!-- Exit Timeout -->


### PR DESCRIPTION
The limit was too set too low to work inside a virtualized environment on macOS Tahoe.
Just inherit the system defaults which will be higher by default.